### PR TITLE
Derived jQueryEvent from EventArgs

### DIFF
--- a/src/Libraries/jQuery/jQuery.Core/jQueryEvent.cs
+++ b/src/Libraries/jQuery/jQuery.Core/jQueryEvent.cs
@@ -18,7 +18,7 @@ namespace jQueryApi {
     /// </summary>
     [Imported]
     [IgnoreNamespace]
-    public sealed class jQueryEvent {
+    public sealed class jQueryEvent : EventArgs {
 
         private jQueryEvent() {
         }


### PR DESCRIPTION
Hi Nikhil, I just made a small change to the jQueryEvent object, deriving it from EventArgs so it can be used in places like the generic arguement in the generic class EventHandler<>

I'm pretty new to github and i hope this is the correct way to help out with ScriptSharp :)

-Kris
