### PR TITLE
Corrected Date formatting to match .NET for all .NET cultures with Gregorian calendars.

### DIFF
--- a/bin/ref/mscorlib.debug.js
+++ b/bin/ref/mscorlib.debug.js
@@ -810,7 +810,7 @@ Date.prototype._netFormat = function Date$_netFormat(format, useLocale) {
 
     if (format.length == 1) {
         switch (format) {
-            case 'f': format = dtf.longDatePattern + ' ' + dtf.shortTimePattern;
+            case 'f': format = dtf.longDatePattern + ' ' + dtf.shortTimePattern; break;
             case 'F': format = dtf.dateTimePattern; break;
 
             case 'd': format = dtf.shortDatePattern; break;
@@ -822,8 +822,8 @@ Date.prototype._netFormat = function Date$_netFormat(format, useLocale) {
             case 'g': format = dtf.shortDatePattern + ' ' + dtf.shortTimePattern; break;
             case 'G': format = dtf.shortDatePattern + ' ' + dtf.longTimePattern; break;
 
-            case 'R': case 'r': format = dtf.gmtDateTimePattern; useUTC = true; break;
-            case 'u': format = dtf.universalDateTimePattern; useUTC = true; break;
+            case 'R': case 'r': dtf = ss.CultureInfo.InvariantCulture.dateFormat; format = dtf.gmtDateTimePattern; break;
+            case 'u': format = dtf.universalDateTimePattern; break;
             case 'U': format = dtf.dateTimePattern; useUTC = true; break;
 
             case 's': format = dtf.sortableDateTimePattern; break;
@@ -835,10 +835,10 @@ Date.prototype._netFormat = function Date$_netFormat(format, useLocale) {
     }
 
     if (!Date._formatRE) {
-        Date._formatRE = /'[^']+'|dddd|ddd|dd|d|MMMM|MMM|MM|M|yyyy|yy|y|hh|h|HH|H|mm|m|ss|s|tt|t|fff|ff|f|zzz|zz|z/g;
+        Date._formatRE = /'.*?[^\\]'|dddd|ddd|dd|d|MMMM|MMM|MM|M|yyyy|yy|y|hh|h|HH|H|mm|m|ss|s|tt|t|fff|ff|f|zzz|zz|z/g;
     }
 
-    var re = Date._formatRE;    
+    var re = Date._formatRE;
     var sb = new ss.StringBuilder();
     var dt = this;
     if (useUTC) {
@@ -947,7 +947,7 @@ Date.prototype._netFormat = function Date$_netFormat(format, useLocale) {
                 break;
             default:
                 if (part.charAt(0) == '\'') {
-                    part = part.substr(1, part.length - 2);
+                    part = part.substr(1, part.length - 2).replace(/\\'/g, '\'');
                 }
                 break;
         }


### PR DESCRIPTION
I wote tests to compare Script# date formatting to .NET formatting.  I tested:
- All .NET cultures which use a Gregorian calendar.
- All .NET standard date/time format strings.

The results were:

1) Standard (not custom) format strings not implemented in Script#: M, m, O, o, Y, y
2) The culture 'mt-MT' has issues because it uses escaped quotes.
3) Except for 'mt-MT' the following format strings worked flawlessly: d, D, F, g, G, s, t, T, U
4) The following format strings don't match, even for 'en-US': f, R, r, u

I fixed the formatting issues for f, R, r, u and added support for escaped quotes to fix 'mt-MT'.

CORRECTION: My test coverage was not as complete as I thought.  Once I fixed my tests I found that 'U' does not work for all dates and cultures.  I'm still investigating.

UPDATE: I've looked into UTC handling and discovered the cause of the discrepancy.  UTC conversion in browsers I tested (FF 4, IE 9, Chrome 11) all use the current DST rules, even for dates where those rules are not valid.  So while the formatting is correct, the conversion is not necessarily correct.  As long as Script# relies on the browser for time zone conversion, there is no getting around this limitation.
