### PR TITLE
Knockout.js 1.3 RC Mapping

### DIFF
--- a/src/Libraries/Knockout/DependentObservable.cs
+++ b/src/Libraries/Knockout/DependentObservable.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using System.Collections;
 
 namespace KnockoutApi {
 
@@ -17,7 +18,7 @@ namespace KnockoutApi {
     /// <typeparam name="T">The type of the contained value.</typeparam>
     [Imported]
     [IgnoreNamespace]
-    public sealed class DependentObservable<T> {
+    public sealed class DependentObservable<T> : IDisposable {
 
         private DependentObservable() {
         }
@@ -39,5 +40,19 @@ namespace KnockoutApi {
         public IDisposable Subscribe(Action<T> changeCallback) {
             return null;
         }
+
+        /// <summary>
+        /// For dependent observables, we throttle *evaluations* so that, no matter how fast its dependencies        
+        /// notify updates, the target doesn't re-evaluate (and hence doesn't notify) faster than a certain rate
+        /// For writable targets (observables, or writable dependent observables), we throttle *writes*        
+        /// so the target cannot change value synchronously or faster than a certain rate
+        /// </summary>
+        /// <param name="options"></param>
+        /// <returns>Extend is Chainable</returns>
+        public DependentObservable<T> Extend(Dictionary options) { return null; }
+
+        public int GetDependenciesCount() { return 0; }
+
+        public void Dispose() { }
     }
 }

--- a/src/Libraries/Knockout/DependentObservableOptions.cs
+++ b/src/Libraries/Knockout/DependentObservableOptions.cs
@@ -38,6 +38,20 @@ namespace KnockoutApi {
             set;
         }
 
+        //
+        // Summary:
+        //  Gets or sets the function to compute the value.
+        [ScriptName("write")]
+        [IntrinsicProperty]
+        public Action<T> SetValueFunction { get; set; }
+
+        //
+        // Summary:
+        //  Gets or sets the function to compute the value.
+        [ScriptName("write")]
+        [IntrinsicProperty]
+        public Action<T[]> SetArrayValueFunction { get; set; }
+
         /// <summary>
         /// Gets the model instance which acts as 'this' in the get value function.
         /// </summary>
@@ -47,5 +61,25 @@ namespace KnockoutApi {
             get;
             set;
         }
+
+        /// <summary>
+        /// "disposeWhenNodeIsRemoved" option both proactively disposes as soon as the node is removed using ko.removeNode(),    
+        /// plus adds a "disposeWhen" callback that, on each evaluation, disposes if the node was removed by some other means.
+        /// </summary>
+        [IntrinsicProperty]
+        public object DisposeWhenNodeIsRemoved {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Pass in a function that evaluates when the Dependency can be disposed
+        /// </summary>
+        [IntrinsicProperty]
+        public Func<bool> DisposeWhen {
+            get;
+            set;
+        }
+
     }
 }

--- a/src/Libraries/Knockout/KnockoutUtils.cs
+++ b/src/Libraries/Knockout/KnockoutUtils.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace KnockoutApi
+{
+    [Imported]
+    [IgnoreNamespace]
+    [ScriptName("ko.utils")]
+    public static class KnockoutUtils
+    {
+        public static T[] ArrayGetDistinctValues<T>(IEnumerable<T> array) {
+            return null;
+        }
+
+        public static T[] ArrayFilter<T>(IEnumerable<T> array, Func<T, bool> predicate) {
+            return null;
+        }
+
+        public static T[] MakeArray<T>(IEnumerable<T> array) {
+            return null;
+        }
+
+        [AlternateSignature] public extern static T UnwrapObservable<T>(T array);
+        [AlternateSignature] public extern static T UnwrapObservable<T>(Observable<T> array);
+        public static T[] UnwrapObservable<T>(ObservableArray<T> array) {
+            return null;
+        }
+
+        public static void PostJson(object urlOrForm, object data, Dictionary options) {
+            return;
+        }
+
+        public static T ParseJson<T>(string jsonString) {
+            return default(T);
+        }
+
+        public static string stringifyJson(object obj) {
+            return null;
+        }
+
+        public static int[] Range(int min, int max) {
+            return null;
+        }
+    }
+}

--- a/src/Libraries/Knockout/Observable.cs
+++ b/src/Libraries/Knockout/Observable.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using System.Collections;
 
 namespace KnockoutApi {
 
@@ -17,10 +18,9 @@ namespace KnockoutApi {
     /// <typeparam name="T">The type of the contained value.</typeparam>
     [Imported]
     [IgnoreNamespace]
-    public sealed class Observable<T> {
+    public class Observable<T> : Subscribable<T> {
 
-        private Observable() {
-        }
+        protected Observable() : base() { }
 
         /// <summary>
         /// Gets the current value within the observable object.
@@ -35,17 +35,41 @@ namespace KnockoutApi {
         /// Sets the value within the observable object.
         /// </summary>
         /// <param name="value">The new value.</param>
+        /// <returns>Specification Supports chaining</returns>
         [ScriptName("")]
-        public void SetValue(T value) {
+        public Observable<T> SetValue(T value) {
+            return null;
         }
 
         /// <summary>
-        /// Subscribes to change notifications raised when the value changes.
+        /// Notifies All Subscribers that the Value has Changed
+        /// Called internally with SetValue
         /// </summary>
-        /// <param name="changeCallback">The callback to invoke.</param>
-        /// <returns>A subscription cookie that can be disposed to unsubscribe.</returns>
-        public IDisposable Subscribe(Action<T> changeCallback) {
-            return null;
-        }
+        public void ValueHasMutated() { }
+
+
+        /// <summary>
+        /// Notifies All Subscribers BEFORE the Value has Changed
+        /// Called internally with SetValue
+        /// </summary>
+        public void ValueWillMutated() { }
+
+        /// <summary>
+        /// For Primitive Types ko will handle Equality internally
+        /// For complex types a supplied function can be assigned to improve 
+        /// change (mutation) detection
+        /// </summary>
+        [IntrinsicProperty]
+        public Func<T, T, bool> EqualityComparer { get; set; }
+
+        /// <summary>
+        /// For dependent observables, we throttle *evaluations* so that, no matter how fast its dependencies        
+        /// notify updates, the target doesn't re-evaluate (and hence doesn't notify) faster than a certain rate
+        /// For writable targets (observables, or writable dependent observables), we throttle *writes*        
+        /// so the target cannot change value synchronously or faster than a certain rate
+        /// </summary>
+        /// <param name="options"></param>
+        /// <returns>Extend is Chainable</returns>
+        public new Observable<T> Extend(Dictionary options) { return null; }
     }
 }

--- a/src/Libraries/Knockout/ObservableArray.cs
+++ b/src/Libraries/Knockout/ObservableArray.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Collections;
 
 namespace KnockoutApi {
 
@@ -19,9 +20,9 @@ namespace KnockoutApi {
     /// <typeparam name="T">The type of the contained values.</typeparam>
     [Imported]
     [IgnoreNamespace]
-    public sealed class ObservableArray<T> {
-
-        private ObservableArray() {
+    public class ObservableArray<T> : Observable<T[]>
+    {
+        protected ObservableArray() : base() {
         }
 
         /// <summary>
@@ -47,11 +48,19 @@ namespace KnockoutApi {
 
         /// <summary>
         /// Gets the underlying items within the observable array.
+        /// This is a Copy of the Values in the Observable
         /// </summary>
         /// <returns>The collection of items.</returns>
         [ScriptName("")]
-        public IReadonlyCollection<T> GetItems() {
+        public T[] GetItems() {
             return null;
+        }
+
+        /// <summary>
+        /// Sets the underlying items within the observable array.
+        /// </summary>
+        [ScriptName("")]
+        public void SetItems(T[] values) {
         }
 
         /// <summary>
@@ -76,6 +85,12 @@ namespace KnockoutApi {
         /// </summary>
         /// <param name="value">The value to add.</param>
         public void Push(T value) {
+        }
+
+        /// <summary>
+        /// Replaces the Specified Item with the NewItem
+        /// </summary>
+        public void Replace(T oldItem, T newItem) {
         }
 
         /// <summary>
@@ -119,6 +134,17 @@ namespace KnockoutApi {
             return default(T);
         }
 
+
+        /// <summary>
+        /// Native Javascript Splice Function
+        /// Modifies the Existing Sequence
+        /// </summary>
+        /// <param name="index">Required. An integer that specifies at what position to add/remove elements</param>
+        /// <param name="howmany">Required. The number of elements to be removed. If set to 0, no elements will be removed</param>
+        /// <param name="args">Optional. The new element(s) to be added to the array</param>
+        public void Splice(int index, int howmany, params T[] args) {            
+        }
+
         /// <summary>
         /// Returns elements from start index to the end of the array.
         /// </summary>
@@ -145,15 +171,6 @@ namespace KnockoutApi {
         }
 
         /// <summary>
-        /// Subscribes to change notifications raised when the value changes.
-        /// </summary>
-        /// <param name="changeCallback">The callback to invoke.</param>
-        /// <returns>A subscription cookie that can be disposed to unsubscribe.</returns>
-        public IDisposable Subscribe(Action<T> changeCallback) {
-            return null;
-        }
-
-        /// <summary>
         /// Performs a sort using the comparator function.
         /// </summary>
         /// <param name="comparator">The comparing function.</param>
@@ -164,7 +181,16 @@ namespace KnockoutApi {
         /// Inserts the value at the beginning of the array.
         /// </summary>
         /// <param name="value">The value to insert.</param>
-        public void Unshift(T value) {
-        }
+        public void Unshift(T value) { }
+
+        /// <summary>
+        /// For dependent observables, we throttle *evaluations* so that, no matter how fast its dependencies        
+        /// notify updates, the target doesn't re-evaluate (and hence doesn't notify) faster than a certain rate
+        /// For writable targets (observables, or writable dependent observables), we throttle *writes*        
+        /// so the target cannot change value synchronously or faster than a certain rate
+        /// </summary>
+        /// <param name="options"></param>
+        /// <returns>Extend is Chainable</returns>
+        public new ObservableArray<T> Extend(Dictionary options) { return null; }
     }
 }

--- a/src/Libraries/Knockout/Subscribable.cs
+++ b/src/Libraries/Knockout/Subscribable.cs
@@ -1,0 +1,59 @@
+// Subscribable.cs
+//
+
+using System;
+using System.Collections;
+using System.Runtime.CompilerServices;
+
+namespace KnockoutApi
+{
+    [Imported]
+    [IgnoreNamespace]
+    public class Subscribable<T>: IDisposable
+    {
+        protected Subscribable() { }
+
+        /// <summary>
+        /// Subscribes to change notifications raised when the value changes.
+        /// </summary>
+        /// <param name="changeCallback">The callback to invoke.</param>
+        /// <returns>A subscription cookie that can be disposed to unsubscribe.</returns>
+        public IDisposable Subscribe(Action<T> changeCallback) { return null; }
+
+        /// <summary>
+        /// Subscribes to change notifications raised when the value changes.
+        /// </summary>
+        /// <param name="changeCallback">The callback to invoke.</param>
+        /// <param name="callBackTarget">callback target</param>
+        /// <returns>A subscription cookie that can be disposed to unsubscribe.</returns>
+        public IDisposable Subscribe(Action<T> changeCallback, object callBackTarget) { return null; }
+
+        /// <summary>
+        /// Subscribes to change notifications raised when the value changes.
+        /// </summary>
+        /// <param name="changeCallback">The callback to invoke.</param>
+        /// <param name="callBackTarget">callback target</param>
+        /// <param name="eventName">event registration</param>
+        /// <returns>A subscription cookie that can be disposed to unsubscribe.</returns>
+        public IDisposable Subscribe(Action<T> changeCallback, object callBackTarget, string eventName) { return null; }
+
+        public void NotifySubscribers(T value) { }
+
+        public void NotifySubscribers(T value, string eventName) { }
+        
+        public int GetSubscriptionsCount() { return 0; }
+
+
+        /// <summary>
+        /// For dependent observables, we throttle *evaluations* so that, no matter how fast its dependencies        
+        /// notify updates, the target doesn't re-evaluate (and hence doesn't notify) faster than a certain rate
+        /// For writable targets (observables, or writable dependent observables), we throttle *writes*        
+        /// so the target cannot change value synchronously or faster than a certain rate
+        /// </summary>
+        /// <param name="options"></param>
+        /// <returns>Extend is Chainable</returns>
+        public Subscribable<T> Extend(Dictionary options) { return null; }
+
+        public void Dispose() { }
+    }
+}


### PR DESCRIPTION
Updated the Knockout Library to reflect the latest Knockout.js 1.3RC API

Major Changes:
Added Subscribable Class
Observable Inherits from Subscribable
ObservableArray Inherits from Subscribable
DependentObservableOptions now has 'Write' Function
Added KnockoutUtils

1.3 API Changes:
Throttling Support (Extenders)
Lower Level Control (Subscribe to Before Changes, Notify Value Has Changed)
Subscribe to 'Custom 'Events'
