### PR TITLE
Knockout API revisions

### DIFF
--- a/src/Libraries/Knockout/Knockout.cs
+++ b/src/Libraries/Knockout/Knockout.cs
@@ -225,6 +225,16 @@ namespace KnockoutApi {
 			return null;
 		}
 
+		/// <summary>
+		/// Converts a model into the equivalent vanilla script object.
+		/// </summary>
+		/// <param name="model">The model object to convert.</param>
+		/// <returns>The vanilla script object representing the model data.</returns>
+		[ScriptName("toJS")]
+		public static T ToObject<T>(T model) {
+			return default(T);
+		}
+		
         /// <summary>
         /// If the provided value is an observable, return its value, otherwise just pass it through.
         /// </summary>

--- a/src/Libraries/Knockout/Knockout.cs
+++ b/src/Libraries/Knockout/Knockout.cs
@@ -231,7 +231,7 @@ namespace KnockoutApi {
 		/// <param name="model">The model object to convert.</param>
 		/// <returns>The vanilla script object representing the model data.</returns>
 		[ScriptName("toJS")]
-		public static T ToObject<T>(T model) {
+		public static T ToObject<T>(object model) {
 			return default(T);
 		}
 		

--- a/src/Libraries/Knockout/Knockout.cs
+++ b/src/Libraries/Knockout/Knockout.cs
@@ -205,6 +205,26 @@ namespace KnockoutApi {
             return null;
         }
 
+		/// <summary>
+		/// Converts a model into the equivalent JSON representation.
+		/// </summary>
+		/// <param name="model">The model object to convert.</param>
+		/// <returns>The JSON string representing the model data.</returns>
+		[ScriptName("toJSON")]
+		public static string ToJson(object model) {
+			return null;
+		}
+
+		/// <summary>
+		/// Converts a model into the equivalent vanilla script object.
+		/// </summary>
+		/// <param name="model">The model object to convert.</param>
+		/// <returns>The vanilla script object representing the model data.</returns>
+		[ScriptName("toJS")]
+		public static object ToObject(object model) {
+			return null;
+		}
+
         /// <summary>
         /// If the provided value is an observable, return its value, otherwise just pass it through.
         /// </summary>

--- a/src/Libraries/Knockout/KnockoutMapping.cs
+++ b/src/Libraries/Knockout/KnockoutMapping.cs
@@ -69,7 +69,27 @@ namespace KnockoutApi {
         public TModel ModelFromObject<TModel>(object data, object mapping) {
             return default(TModel);
         }
-
+		
+		/// <summary>
+		/// Unwraps the given view model
+		/// </summary>
+		/// <param name="model">The model to unwrap</param>
+		/// <returns>The unwrapped view model</returns>
+		[ScriptName("toJS")]
+		public object ModelToObject(object model) {
+			return null;
+		}
+		
+		/// <summary>
+		/// Unwraps the given view model
+		/// </summary>
+		/// <param name="model">The model to unwrap</param>
+		/// <returns>The unwrapped view model</returns>
+		[ScriptName("toJS")]
+		public T ModelToObject<T>(T model) {
+			return default(T);
+		}
+		
         /// <summary>
         /// Updates the specified model with the specified JSON string.
         /// </summary>

--- a/src/Libraries/Knockout/KnockoutMapping.cs
+++ b/src/Libraries/Knockout/KnockoutMapping.cs
@@ -71,26 +71,6 @@ namespace KnockoutApi {
         }
 
         /// <summary>
-        /// Converts a model into the equivalent JSON representation.
-        /// </summary>
-        /// <param name="model">The model object to convert.</param>
-        /// <returns>The JSON string representing the model data.</returns>
-        [ScriptAlias("ko.toJSON")]
-        public string ToJson(object model) {
-            return null;
-        }
-
-        /// <summary>
-        /// Converts a model into the equivalent vanilla script object.
-        /// </summary>
-        /// <param name="model">The model object to convert.</param>
-        /// <returns>The vanilla script object representing the model data.</returns>
-        [ScriptAlias("ko.toJS")]
-        public object ToObject(object model) {
-            return null;
-        }
-
-        /// <summary>
         /// Updates the specified model with the specified JSON string.
         /// </summary>
         /// <typeparam name="TModel">The tyoe of the model.</typeparam>

--- a/src/Libraries/Knockout/KnockoutMapping.cs
+++ b/src/Libraries/Knockout/KnockoutMapping.cs
@@ -86,7 +86,7 @@ namespace KnockoutApi {
 		/// <param name="model">The model to unwrap</param>
 		/// <returns>The unwrapped view model</returns>
 		[ScriptName("toJS")]
-		public T ModelToObject<T>(T model) {
+		public T ModelToObject<T>(object model) {
 			return default(T);
 		}
 		

--- a/src/Libraries/jQuery/jQuery.Core/jQueryObject.cs
+++ b/src/Libraries/jQuery/jQuery.Core/jQueryObject.cs
@@ -2266,55 +2266,6 @@ namespace jQueryApi {
             return null;
         }
 
-		/// <summary>
-		/// Removes an event handler which has been created by called On()
-		/// </summary>
-		/// <param name="eventsMap">A dictionary in which the string keys represent the event names, and the values represent the handler which was previously attached to that event</param>
-		/// <returns>The current jQueryObject.</returns>
-		public jQueryObject Off(Dictionary eventsMap) {
-			return null;
-		}
-
-		/// <summary>
-		/// Removes an event handler which has been created by called On()
-		/// </summary>
-		/// <param name="eventsMap">A dictionary in which the string keys represent the event names, and the values represent the handler which was previously attached to that event</param>
-		/// <param name="selector">A selector which should match the one originally passed to On()</param>
-		/// <returns>The current jQueryObject.</returns>
-		public jQueryObject Off(Dictionary eventsMap, string selector) {
-			return null;
-		}
-
-		/// <summary>
-		/// Removes an event handler which has been created by called On()
-		/// </summary>
-		/// <param name="events">One or more space-separated event types and optional namespaces</param>
-		/// <returns>The current jQueryObject.</returns>
-		public jQueryObject Off(string events) {
-			return null;
-		}
-
-		/// <summary>
-		/// Removes an event handler which has been created by called On()
-		/// </summary>
-		/// <param name="events">One or more space-separated event types and optional namespaces</param>
-		/// <param name="selector">A selector which should match the one originally passed to On()</param>
-		/// <returns>The current jQueryObject.</returns>
-		public jQueryObject Off(string events, string selector) {
-			return null;
-		}
-
-		/// <summary>
-		/// Removes an event handler which has been created by called On()
-		/// </summary>
-		/// <param name="events">One or more space-separated event types and optional namespaces</param>
-		/// <param name="selector">A selector which should match the one originally passed to On()</param>
-		/// <param name="eventHandler">A handler function previously attached for the event(s)</param>
-		/// <returns>The current jQueryObject.</returns>
-		public jQueryObject Off(string events, string selector, jQueryEventHandler eventHandler) {
-			return null;
-		}
-
         /// <summary>
         /// Sets the position of the matched elements relative to the document.
         /// </summary>
@@ -2351,69 +2302,6 @@ namespace jQueryApi {
         public jQueryObject OffsetParent() {
             return null;
         }
-
-		/// <summary>
-		/// Attaches an event handler function for one or more events to the selected elements.
-		/// </summary>
-		/// <param name="eventName">The name of the event</param>
-		/// <param name="eventHandler">The event handler to be invoked</param>
-		/// <returns>The current jQueryObject.</returns>
-		public jQueryObject On(string eventName, jQueryEventHandler eventHandler) {
-			return null;
-		}
-
-		/// <summary>
-		/// Attaches an event handler function for one or more events to the selected elements.
-		/// </summary>
-		/// <param name="eventName">The name of the event</param>
-		/// <param name="selector">A selector string to filter the descendants of the selected elements that trigger the event.</param>
-		/// <param name="eventHandler">The event handler to be invoked</param>
-		/// <returns>The current jQueryObject.</returns>
-		public jQueryObject On(string eventName, string selector, jQueryEventHandler eventHandler) {
-			return null;
-		}
-
-		/// <summary>
-		/// Attaches an event handler function for one or more events to the selected elements.
-		/// </summary>
-		/// <param name="eventName">The name of the event</param>
-		/// <param name="selector">A selector string to filter the descendants of the selected elements that trigger the event.</param>
-		/// <param name="data">A custom data structure to be passed to the handler</param>
-		/// <param name="eventHandler">The event handler to be invoked</param>
-		/// <returns>The current jQueryObject.</returns>
-		public jQueryObject On(string eventName, string selector, object data, jQueryEventHandler eventHandler) {
-			return null;
-		}
-
-		/// <summary>
-		/// Attaches an event handler function for one or more events to the selected elements.
-		/// </summary>
-		/// <param name="eventsMap">A dictionary in which the string keys represent the event names, and the values represent the handler for that event.</param>
-		/// <returns>The current jQueryObject</returns>
-		public jQueryObject On(Dictionary eventsMap) {
-			return null;
-		}
-
-		/// <summary>
-		/// Attaches an event handler function for one or more events to the selected elements.
-		/// </summary>
-		/// <param name="eventsMap">A dictionary in which the string keys represent the event names, and the values represent the handler for that event.</param>
-		/// <param name="selector">A selector string to filter the descendants of the selected elements that trigger the event.</param>
-		/// <returns>The current jQueryObject</returns>
-		public jQueryObject On(Dictionary eventsMap, string selector) {
-			return null;
-		}
-
-		/// <summary>
-		/// Attaches an event handler function for one or more events to the selected elements.
-		/// </summary>
-		/// <param name="eventsMap">A dictionary in which the string keys represent the event names, and the values represent the handler for that event.</param>
-		/// <param name="selector">A selector string to filter the descendants of the selected elements that trigger the event.</param>
-		/// <param name="data">A custom data structure to be passed to the handler</param>
-		/// <returns>The current jQueryObject</returns>
-		public jQueryObject On(Dictionary eventsMap, string selector, object data) {
-			return null;
-		}
 
         /// <summary>
         /// Attaches a handler for the handling the specified event once on the matched

--- a/src/Libraries/jQuery/jQuery.Core/jQueryObject.cs
+++ b/src/Libraries/jQuery/jQuery.Core/jQueryObject.cs
@@ -2266,6 +2266,55 @@ namespace jQueryApi {
             return null;
         }
 
+		/// <summary>
+		/// Removes an event handler which has been created by called On()
+		/// </summary>
+		/// <param name="eventsMap">A dictionary in which the string keys represent the event names, and the values represent the handler which was previously attached to that event</param>
+		/// <returns>The current jQueryObject.</returns>
+		public jQueryObject Off(Dictionary eventsMap) {
+			return null;
+		}
+
+		/// <summary>
+		/// Removes an event handler which has been created by called On()
+		/// </summary>
+		/// <param name="eventsMap">A dictionary in which the string keys represent the event names, and the values represent the handler which was previously attached to that event</param>
+		/// <param name="selector">A selector which should match the one originally passed to On()</param>
+		/// <returns>The current jQueryObject.</returns>
+		public jQueryObject Off(Dictionary eventsMap, string selector) {
+			return null;
+		}
+
+		/// <summary>
+		/// Removes an event handler which has been created by called On()
+		/// </summary>
+		/// <param name="events">One or more space-separated event types and optional namespaces</param>
+		/// <returns>The current jQueryObject.</returns>
+		public jQueryObject Off(string events) {
+			return null;
+		}
+
+		/// <summary>
+		/// Removes an event handler which has been created by called On()
+		/// </summary>
+		/// <param name="events">One or more space-separated event types and optional namespaces</param>
+		/// <param name="selector">A selector which should match the one originally passed to On()</param>
+		/// <returns>The current jQueryObject.</returns>
+		public jQueryObject Off(string events, string selector) {
+			return null;
+		}
+
+		/// <summary>
+		/// Removes an event handler which has been created by called On()
+		/// </summary>
+		/// <param name="events">One or more space-separated event types and optional namespaces</param>
+		/// <param name="selector">A selector which should match the one originally passed to On()</param>
+		/// <param name="eventHandler">A handler function previously attached for the event(s)</param>
+		/// <returns>The current jQueryObject.</returns>
+		public jQueryObject Off(string events, string selector, jQueryEventHandler eventHandler) {
+			return null;
+		}
+
         /// <summary>
         /// Sets the position of the matched elements relative to the document.
         /// </summary>
@@ -2302,6 +2351,69 @@ namespace jQueryApi {
         public jQueryObject OffsetParent() {
             return null;
         }
+
+		/// <summary>
+		/// Attaches an event handler function for one or more events to the selected elements.
+		/// </summary>
+		/// <param name="eventName">The name of the event</param>
+		/// <param name="eventHandler">The event handler to be invoked</param>
+		/// <returns>The current jQueryObject.</returns>
+		public jQueryObject On(string eventName, jQueryEventHandler eventHandler) {
+			return null;
+		}
+
+		/// <summary>
+		/// Attaches an event handler function for one or more events to the selected elements.
+		/// </summary>
+		/// <param name="eventName">The name of the event</param>
+		/// <param name="selector">A selector string to filter the descendants of the selected elements that trigger the event.</param>
+		/// <param name="eventHandler">The event handler to be invoked</param>
+		/// <returns>The current jQueryObject.</returns>
+		public jQueryObject On(string eventName, string selector, jQueryEventHandler eventHandler) {
+			return null;
+		}
+
+		/// <summary>
+		/// Attaches an event handler function for one or more events to the selected elements.
+		/// </summary>
+		/// <param name="eventName">The name of the event</param>
+		/// <param name="selector">A selector string to filter the descendants of the selected elements that trigger the event.</param>
+		/// <param name="data">A custom data structure to be passed to the handler</param>
+		/// <param name="eventHandler">The event handler to be invoked</param>
+		/// <returns>The current jQueryObject.</returns>
+		public jQueryObject On(string eventName, string selector, object data, jQueryEventHandler eventHandler) {
+			return null;
+		}
+
+		/// <summary>
+		/// Attaches an event handler function for one or more events to the selected elements.
+		/// </summary>
+		/// <param name="eventsMap">A dictionary in which the string keys represent the event names, and the values represent the handler for that event.</param>
+		/// <returns>The current jQueryObject</returns>
+		public jQueryObject On(Dictionary eventsMap) {
+			return null;
+		}
+
+		/// <summary>
+		/// Attaches an event handler function for one or more events to the selected elements.
+		/// </summary>
+		/// <param name="eventsMap">A dictionary in which the string keys represent the event names, and the values represent the handler for that event.</param>
+		/// <param name="selector">A selector string to filter the descendants of the selected elements that trigger the event.</param>
+		/// <returns>The current jQueryObject</returns>
+		public jQueryObject On(Dictionary eventsMap, string selector) {
+			return null;
+		}
+
+		/// <summary>
+		/// Attaches an event handler function for one or more events to the selected elements.
+		/// </summary>
+		/// <param name="eventsMap">A dictionary in which the string keys represent the event names, and the values represent the handler for that event.</param>
+		/// <param name="selector">A selector string to filter the descendants of the selected elements that trigger the event.</param>
+		/// <param name="data">A custom data structure to be passed to the handler</param>
+		/// <returns>The current jQueryObject</returns>
+		public jQueryObject On(Dictionary eventsMap, string selector, object data) {
+			return null;
+		}
 
         /// <summary>
         /// Attaches a handler for the handling the specified event once on the matched


### PR DESCRIPTION
I've made some revisions to the Knockout bindings to more closely reflect the actual API.

Originally, the methods toJS and toJSON were implemented on Knockout.Mapping, whereas actually these methods exist on the core Knockout static object in the actual API. Thanks to the ScriptAlias attribute, these were being generated correctly in the Javascript, but it would be better if the Script# API reflected the actual API more closely. I have moved these into the correct place.

I've also added back in the toJS method which IS part of the Mapping plugin, in the form of ModelToObject (and ModelToObject<T>) with the correct ScriptName attribute.
