### PR TITLE
"async"  - new C# keyword

### DIFF
--- a/src/Libraries/Web/Net/XmlHttpRequest.cs
+++ b/src/Libraries/Web/Net/XmlHttpRequest.cs
@@ -77,16 +77,16 @@ namespace System.Net {
         public void Open(HttpVerb verb, string url) {
         }
 
-        public void Open(string method, string url, bool async) {
+        public void Open(string method, string url, bool @async) {
         }
 
-        public void Open(HttpVerb verb, string url, bool async) {
+        public void Open(HttpVerb verb, string url, bool @async) {
         }
 
-        public void Open(string method, string url, bool async, string userName, string password) {
+        public void Open(string method, string url, bool @async, string userName, string password) {
         }
 
-        public void Open(HttpVerb verb, string url, bool async, string userName, string password) {
+        public void Open(HttpVerb verb, string url, bool @async, string userName, string password) {
         }
 
         public void Send() {


### PR DESCRIPTION
I could't compile because "async" is a new keyword in C# so I had to rename the arguments.
