### PR TITLE
Added overload for ObservableArray<T>.RemoveAll(), taking no arguments.

### DIFF
--- a/src/Libraries/Knockout/ObservableArray.cs
+++ b/src/Libraries/Knockout/ObservableArray.cs
@@ -109,6 +109,14 @@ namespace KnockoutApi {
         }
 
         /// <summary>
+        /// Removes all values from the array.
+        /// </summary>
+        /// <returns>The removed values</returns>
+        public T[] RemoveAll() {
+            return null;
+        }
+
+        /// <summary>
         /// Removes all values that satisfy the given parameters and returns them.
         /// </summary>
         /// <param name="values">An array of items to remove.</param>


### PR DESCRIPTION
This is an overload which is missing, according to the official API.

http://knockoutjs.com/documentation/observableArrays.html
