### PR TITLE
Making KnockoutMapping strongly typed

### DIFF
--- a/src/Libraries/Knockout/Knockout.csproj
+++ b/src/Libraries/Knockout/Knockout.csproj
@@ -47,6 +47,8 @@
     <Compile Include="DependentObservableOptions.cs" />
     <Compile Include="BindingHandler.cs" />
     <Compile Include="KnockoutMapping.cs" />
+    <Compile Include="KnockoutMappingPropertySpecification.cs" />
+    <Compile Include="KnockoutMappingSpecification.cs" />
     <Compile Include="KnockoutUtils.cs" />
     <Compile Include="ObservableArray.cs" />
     <Compile Include="DependentObservable.cs" />
@@ -70,6 +72,9 @@
       <Project>{3681A9A8-FC40-4125-B842-7775713C8DCE}</Project>
       <Name>Web</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">

--- a/src/Libraries/Knockout/Knockout.csproj
+++ b/src/Libraries/Knockout/Knockout.csproj
@@ -73,9 +73,6 @@
       <Name>Web</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">
     <Copy SourceFiles="@(ScriptInfo)" DestinationFiles="$(OutputPath)$(AssemblyName).txt" />

--- a/src/Libraries/Knockout/KnockoutMapping.cs
+++ b/src/Libraries/Knockout/KnockoutMapping.cs
@@ -39,7 +39,8 @@ namespace KnockoutApi {
         /// <param name="mapping">The mapping rules to apply.</param>
         /// <returns>A new instance of the model.</returns>
         [ScriptName("fromJSON")]
-        public TModel ModelFromJson<TModel>(string jsonData, object mapping) {
+        public TModel ModelFromJson<TModel>(string jsonData, KnockoutMappingSpecification mapping)
+        {
             return default(TModel);
         }
 
@@ -63,7 +64,8 @@ namespace KnockoutApi {
         /// <param name="mapping">The mapping rules to apply.</param>
         /// <returns>A new instance of the model.</returns>
         [ScriptName("fromJS")]
-        public TModel ModelFromObject<TModel>(object data, object mapping) {
+        public TModel ModelFromObject<TModel>(object data, KnockoutMappingSpecification mapping)
+        {
             return default(TModel);
         }
 
@@ -77,7 +79,8 @@ namespace KnockoutApi {
         /// <param name="target">The mapping rules to apply.</param>
         /// <returns>A new instance of the model.</returns>
         [ScriptName("fromJS")]
-        public TModel ModelFromObject<TModel>(object data, object mapping, TModel target) {
+        public TModel ModelFromObject<TModel>(object data, KnockoutMappingSpecification mapping, TModel target)
+        {
             return default(TModel);
         }
 

--- a/src/Libraries/Knockout/KnockoutMappingPropertySpecification.cs
+++ b/src/Libraries/Knockout/KnockoutMappingPropertySpecification.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Runtime.CompilerServices;
 
 namespace KnockoutApi

--- a/src/Libraries/Knockout/KnockoutMappingPropertySpecification.cs
+++ b/src/Libraries/Knockout/KnockoutMappingPropertySpecification.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Runtime.CompilerServices;
+
+namespace KnockoutApi
+{
+    [IgnoreNamespace]
+    [Imported]
+    [ScriptName("Object")]
+    public abstract class KnockoutMappingPropertySpecification
+    {
+        protected KnockoutMappingPropertySpecification()
+        {
+        }
+    }
+
+    [IgnoreNamespace]
+    [Imported]
+    [ScriptName("Object")]
+    public class KnockoutMappingPropertySpecification<TModel> : KnockoutMappingPropertySpecification
+    {
+        [IntrinsicProperty]
+        public Func<MappingCreateOptions, TModel> Create
+        {
+            get
+            {
+                Func<MappingCreateOptions, TModel> func = null;
+                return func;
+            }
+            set
+            {
+            }
+        }
+
+        [IntrinsicProperty]
+        public Func<MappingUpdateOptions, TModel> Update
+        {
+            get
+            {
+                Func<MappingUpdateOptions, TModel> func = null;
+                return func;
+            }
+            set
+            {
+            }
+        }
+
+    }
+
+    [IgnoreNamespace]
+    [Imported]
+    [ScriptName("Object")]
+    public class MappingCreateOptions
+    {
+        [IntrinsicProperty]
+        public object Data
+        {
+            get;
+            set;
+        }
+
+        [IntrinsicProperty]
+        public object Parent
+        {
+            get;
+            set;
+        }
+    }
+
+    [IgnoreNamespace]
+    [Imported]
+    [ScriptName("Object")]
+    public class MappingUpdateOptions
+    {
+        [IntrinsicProperty]
+        public object Data
+        {
+            get;
+            set;
+        }
+
+        [IntrinsicProperty]
+        public object Observable
+        {
+            get;
+            set;
+        }
+
+        [IntrinsicProperty]
+        public object Parent
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/src/Libraries/Knockout/KnockoutMappingSpecification.cs
+++ b/src/Libraries/Knockout/KnockoutMappingSpecification.cs
@@ -1,0 +1,67 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace KnockoutApi
+{
+    [IgnoreNamespace]
+    [Imported]
+    [ScriptName("Object")]
+    public class KnockoutMappingSpecification
+    {
+        [IntrinsicProperty]
+        public string[] Copy
+        {
+            get
+            {
+                string[] strArray = null;
+                return strArray;
+            }
+            set
+            {
+            }
+        }
+
+        [IntrinsicProperty]
+        public string[] Ignore
+        {
+            get
+            {
+                string[] strArray = null;
+                return strArray;
+            }
+            set
+            {
+            }
+        }
+
+        [IntrinsicProperty]
+        public string[] Include
+        {
+            get
+            {
+                string[] strArray = null;
+                return strArray;
+            }
+            set
+            {
+            }
+        }
+
+        [IntrinsicProperty]
+        public KnockoutMappingPropertySpecification this[string propertyName]
+        {
+            get
+            {
+                KnockoutMappingPropertySpecification knockoutMappingPropertySpecification = null;
+                return knockoutMappingPropertySpecification;
+            }
+            set
+            {
+            }
+        }
+
+        public KnockoutMappingSpecification()
+        {
+        }
+    }
+
+}


### PR DESCRIPTION
Adding a KnockoutMappingSpecification to strongly type the mapping
options
