### PR TITLE
Add support for String.IsNullOrWhiteSpace

### DIFF
--- a/src/Core/CoreLib/String.cs
+++ b/src/Core/CoreLib/String.cs
@@ -232,6 +232,10 @@ namespace System {
             return false;
         }
 
+        public static bool IsNullOrWhiteSpace(string s) {
+            return false;
+        }
+
         public int LastIndexOf(Char ch) {
             return 0;
         }

--- a/src/Core/CoreScript/Extensions/String.js
+++ b/src/Core/CoreScript/Extensions/String.js
@@ -138,6 +138,10 @@ String.isNullOrEmpty = function#? DEBUG String$isNullOrEmpty##(s) {
     return !s || !s.length;
 }
 
+String.isNullOrWhiteSpace = function#? DEBUG String$isNullOrWhiteSpace##(s) {
+    return String.isNullOrEmpty(s) || s.trim() === "";
+}
+
 String.prototype.lastIndexOfAny = function#? DEBUG String$lastIndexOfAny##(chars, startIndex, count) {
     var length = this.length;
     if (!length) {

--- a/tests/CoreLib/TestString.htm
+++ b/tests/CoreLib/TestString.htm
@@ -85,5 +85,15 @@ test('htmlDecode', function() {
   QUnit.equal('&lt;h1&gt;a &quot;aaa&quot; &amp; a &quot;bbb&quot;&lt;/h1&gt;'.htmlDecode(), '<h1>a "aaa" & a "bbb"</h1>');
 });
 
+test('isNullOrWhiteSpace', function () {
+  QUnit.equal(String.isNullOrWhiteSpace(null), true, 'null should be true');
+  QUnit.equal(String.isNullOrWhiteSpace(undefined), true, 'undefined should be true');
+  QUnit.equal(String.isNullOrWhiteSpace(), true, 'no param, should be true');
+  QUnit.equal(String.isNullOrWhiteSpace(""), true, 'empty string, should be true');
+  QUnit.equal(String.isNullOrWhiteSpace(" "), true, 'white space, should be true');
+  QUnit.equal(String.isNullOrWhiteSpace("   "), true, 'triple white space, should be true');
+  QUnit.equal(String.isNullOrWhiteSpace("aaa"), false, 'aaa, should be false');
+});
+
 </script>
 </html>

--- a/tests/CoreLib/TestString.htm
+++ b/tests/CoreLib/TestString.htm
@@ -85,6 +85,15 @@ test('htmlDecode', function() {
   QUnit.equal('&lt;h1&gt;a &quot;aaa&quot; &amp; a &quot;bbb&quot;&lt;/h1&gt;'.htmlDecode(), '<h1>a "aaa" & a "bbb"</h1>');
 });
 
+test('isNullOrEmpty', function () {
+  QUnit.equal(String.isNullOrEmpty(null), true, 'null should be true');
+  QUnit.equal(String.isNullOrEmpty(undefined), true, 'undefined should be true');
+  QUnit.equal(String.isNullOrEmpty(), true, 'no param, should be true');
+  QUnit.equal(String.isNullOrEmpty(""), true, 'empty string, should be true');
+  QUnit.equal(String.isNullOrEmpty(" "), false, 'white space, should be false');
+  QUnit.equal(String.isNullOrEmpty("aaa"), false, 'aaa, should be false');
+});
+
 test('isNullOrWhiteSpace', function () {
   QUnit.equal(String.isNullOrWhiteSpace(null), true, 'null should be true');
   QUnit.equal(String.isNullOrWhiteSpace(undefined), true, 'undefined should be true');


### PR DESCRIPTION
Add support for `String.IsNullOrWhiteSpace` by adding the method to both CoreLib and CoreScript.

I also added JavaScript tests for both `isNullOrWhiteSpace` and `isNullOrEmpty`.
