### PR TITLE
Enumeration for Knockout CompareResult status

### DIFF
--- a/src/Libraries/Knockout/CompareResult.cs
+++ b/src/Libraries/Knockout/CompareResult.cs
@@ -13,7 +13,8 @@ namespace KnockoutApi {
     public class CompareResult<T> {
 
         [IntrinsicProperty]
-        public string Status {
+        public CompareResultStatus Status
+        {
             get;
             set;
         }
@@ -23,5 +24,12 @@ namespace KnockoutApi {
             get;
             set;
         }
+    }
+
+    [NamedValues]
+    public enum CompareResultStatus{
+        added,
+        deleted,
+        retained
     }
 }


### PR DESCRIPTION
adding an enum to "strongly type" the status on CompareResult
