### PR TITLE
Added OriginalEvent to jQueryEvent object.

### DIFF
--- a/src/Libraries/jQuery/jQuery.Core/jQueryEvent.cs
+++ b/src/Libraries/jQuery/jQuery.Core/jQueryEvent.cs
@@ -192,6 +192,16 @@ namespace jQueryApi {
         }
 
         /// <summary>
+        /// Gets the original DOM event which spawned this event.
+        /// </summary>
+        [ScriptProperty]
+        public ElementEvent OriginalEvent {
+            get{
+                return null;
+            }
+        }
+
+        /// <summary>
         /// Gets the number of milliseconds since Jan 1, 1970, when the event
         /// was triggered.
         /// </summary>


### PR DESCRIPTION
http://api.jquery.com/category/events/event-object/
OriginalEvent is provided on every jQueryEvent, and usually contains a lot of useful, specialized information (once it is cast to the correct event type)
