### PR TITLE
Single line delegate declaration + invocation

### DIFF
--- a/src/Core/Compiler/Compiler.csproj
+++ b/src/Core/Compiler/Compiler.csproj
@@ -353,6 +353,7 @@
     <Compile Include="ScriptModel\Expressions\BinaryExpression.cs" />
     <Compile Include="ScriptModel\Expressions\ConditionalExpression.cs" />
     <Compile Include="ScriptModel\Expressions\NewExpression.cs" />
+    <Compile Include="ScriptModel\Expressions\NewDelegateExpression.cs" />
     <Compile Include="ScriptModel\Expressions\UnaryExpression.cs" />
     <Compile Include="ScriptModel\Expressions\ThisExpression.cs" />
     <Compile Include="ScriptModel\Expressions\TypeExpression.cs" />

--- a/src/Core/Compiler/Generator/ExpressionGenerator.cs
+++ b/src/Core/Compiler/Generator/ExpressionGenerator.cs
@@ -410,6 +410,9 @@ namespace ScriptSharp.Generator {
                 case ExpressionType.InlineScript:
                     GenerateInlineScriptExpression(generator, symbol, (InlineScriptExpression)expression);
                     break;
+                case ExpressionType.NewDelegate:
+                    GenerateExpression(generator, symbol, ((NewDelegateExpression)expression).TypeExpression);
+                    break;
                 default:
                     Debug.Fail("Unexpected expression type: " + expression.Type);
                     break;

--- a/src/Core/Compiler/ScriptModel/Expressions/ExpressionType.cs
+++ b/src/Core/Compiler/ScriptModel/Expressions/ExpressionType.cs
@@ -53,6 +53,8 @@ namespace ScriptSharp.ScriptModel {
 
         LateBound = 21,
 
-        InlineScript = 22
+        InlineScript = 22,
+
+        NewDelegate = 23,
     }
 }

--- a/src/Core/Compiler/ScriptModel/Expressions/NewDelegateExpression.cs
+++ b/src/Core/Compiler/ScriptModel/Expressions/NewDelegateExpression.cs
@@ -1,0 +1,69 @@
+// NewExpression.cs
+// Script#/Core/Compiler
+// This source code is subject to terms and conditions of the Apache License, Version 2.0.
+//
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+
+namespace ScriptSharp.ScriptModel {
+
+    internal sealed class NewDelegateExpression : Expression {
+
+        private TypeSymbol _associatedType;
+        private Expression _typeExpression;
+
+        public NewDelegateExpression(TypeSymbol associatedType)
+            : base(ExpressionType.NewDelegate, associatedType, SymbolFilter.Public | SymbolFilter.InstanceMembers) {
+
+            Debug.Assert(associatedType.Type == SymbolType.Delegate);
+            _associatedType = associatedType;
+        }
+
+        public NewDelegateExpression(Expression typeExpression, TypeSymbol associatedType)
+            : base(ExpressionType.NewDelegate, associatedType, SymbolFilter.Public | SymbolFilter.InstanceMembers) {
+
+            Debug.Assert(associatedType.Type == SymbolType.Delegate);
+            _typeExpression = typeExpression;
+            _associatedType = associatedType;
+        }
+
+        public TypeSymbol AssociatedType {
+            get {
+                return _associatedType;
+            }
+        }
+
+        public bool IsSpecificType {
+            get {
+                return (_typeExpression == null);
+            }
+        }
+
+        public override bool RequiresThisContext {
+            get
+            {
+                if ((_typeExpression != null) && _typeExpression.RequiresThisContext) {
+                    return true;
+                }
+
+                return false;
+            }
+        }
+
+        protected override bool IsParenthesisRedundant {
+            get {
+                return false;
+            }
+        }
+
+        public Expression TypeExpression {
+            get {
+                return _typeExpression;
+            }
+        }
+    }
+}

--- a/tests/TestCases/Expression/AnonymousMethods/Baseline.txt
+++ b/tests/TestCases/Expression/AnonymousMethods/Baseline.txt
@@ -61,6 +61,27 @@ define('test', ['ss'], function(ss) {
           var numbers = [ $this._n * 2 ];
         });
       });
+      var j = 0;
+      (function() {
+        $this._n++;
+      })();
+      (function() {
+        j++;
+      })();
+      (function(i, s, b) {
+        i++;
+        b = ss.emptyString(s);
+      })(j, 'foo', false);
+      (function(i, s, b) {
+        i++;
+        b = ss.emptyString(s);
+      })(j, 'foo', false);
+      j = (function(k) {
+        return k + 1;
+      })(3);
+      j = (function(k) {
+        return k + 1;
+      })(3);
     },
     BBB: function(o) {
       var s = new ExpressionTests$SomeClass(function() {

--- a/tests/TestCases/Expression/AnonymousMethods/Code.cs
+++ b/tests/TestCases/Expression/AnonymousMethods/Code.cs
@@ -7,6 +7,8 @@ namespace ExpressionTests {
 
     public delegate void Foo(int i, string s, bool b);
 
+    public delegate int Bar(int i);
+
     public delegate void Callback();
 
     public class SomeClass {
@@ -58,6 +60,33 @@ namespace ExpressionTests {
                     int[] numbers = new int[] { _n * 2 };
                 });
             });
+
+            int j = 0;
+            new Callback(delegate {
+                this._n++;
+            }).Invoke();
+
+            new Callback(delegate {
+                j++;
+            })();
+
+            new Foo(delegate(int i, string s, bool b) {
+                i++;
+                b = string.IsNullOrEmpty(s);
+            }).Invoke(j, "foo", false);
+
+            new Foo(delegate(int i, string s, bool b) {
+                i++;
+                b = string.IsNullOrEmpty(s);
+            })(j, "foo", false);
+
+            j = new Bar(delegate (int k) { 
+                return k + 1; 
+            }).Invoke(3);
+
+            j = new Bar(delegate(int k) {
+                return k + 1;
+            })(3);
         }
 
         public void BBB(object o) {


### PR DESCRIPTION
Currently, S# doesn't support declaring and invocing delegates on a
single line:

new Callback(delegate {}).Invoke() compiles to function() {};

This change adds support for declaring and invoking a delegate on one
line.
