### PR TITLE
Fix crash when referencing non-int enums

### DIFF
--- a/src/Core/Build/Tasks/ScriptCompilerTask.cs
+++ b/src/Core/Build/Tasks/ScriptCompilerTask.cs
@@ -34,6 +34,7 @@ namespace ScriptSharp.Tasks {
         private bool _minimize;
         private bool _crunch;
         private bool _copyReferences;
+        private bool _localeSubfolders;
         private string _referencesPath;
         private string _outputPath;
         private string _deploymentPath;
@@ -107,6 +108,15 @@ namespace ScriptSharp.Tasks {
             }
             set {
                 _deploymentPath = value;
+            }
+        }
+
+        public bool LocaleSubfolders {
+            get {
+                return _localeSubfolders;
+            }
+            set {
+                _localeSubfolders = value;
             }
         }
 
@@ -399,7 +409,12 @@ namespace ScriptSharp.Tasks {
 
                 string extension = includeTests ? "test.js" : (minimize ? "min.js" : "js");
                 if (String.IsNullOrEmpty(locale) == false) {
-                    extension = locale + "." + extension;
+                    if (LocaleSubfolders) {
+                        outputPath = Path.Combine(outputPath, locale);
+                    }
+                    else {
+                        extension = locale + "." + extension;
+                    }
                 }
 
                 if (Directory.Exists(outputPath) == false) {

--- a/src/Core/Compiler/Importer/MetadataImporter.cs
+++ b/src/Core/Compiler/Importer/MetadataImporter.cs
@@ -176,10 +176,9 @@ namespace ScriptSharp.Importer {
                 }
 
                 string fieldName = field.Name;
-                int fieldValue = (int)field.Constant;
 
                 EnumerationFieldSymbol fieldSymbol =
-                    new EnumerationFieldSymbol(fieldName, enumTypeSymbol, fieldValue, fieldType);
+                    new EnumerationFieldSymbol(fieldName, enumTypeSymbol, field.Constant, fieldType);
                 ImportMemberDetails(fieldSymbol, null, field);
 
                 enumTypeSymbol.AddMember(fieldSymbol);


### PR DESCRIPTION
S# crashes when we reference an enum that extends from something other
than int32 due to an invalid cast exception.
