### PR TITLE
Write ";" after static functions

### DIFF
--- a/src/Core/Compiler/Generator/MemberGenerator.cs
+++ b/src/Core/Compiler/Generator/MemberGenerator.cs
@@ -301,7 +301,7 @@ namespace ScriptSharp.Generator {
             writer.Write("}");
 
             if (instanceMember == false) {
-                writer.WriteLine();
+                writer.WriteLine(";");
             }
         }
 
@@ -339,7 +339,7 @@ namespace ScriptSharp.Generator {
             writer.Write("}");
 
             if (instanceMember == false) {
-                writer.WriteLine();
+                writer.WriteLine(";");
             }
 
             if (propertySymbol.IsReadOnly == false) {
@@ -378,7 +378,7 @@ namespace ScriptSharp.Generator {
                 writer.Write("}");
 
                 if (instanceMember == false) {
-                    writer.WriteLine();
+                    writer.WriteLine(";");
                 }
             }
         }

--- a/tests/TestCases/Basic/DocComments/Baseline.txt
+++ b/tests/TestCases/Basic/DocComments/Baseline.txt
@@ -64,7 +64,7 @@ define('test', ['ss'], function(ss) {
     /// </summary>
     /// <value type="Number" integer="true"></value>
     return 0;
-  }
+  };
   BasicTests$BaseClass.staticMethod = function(length) {
     /// <summary>
     /// A static method.
@@ -72,7 +72,7 @@ define('test', ['ss'], function(ss) {
     /// <param name="length" type="Number" integer="true">
     /// The length.
     /// </param>
-  }
+  };
   var BasicTests$BaseClass$ = {
     get_name: function() {
       /// <summary>
@@ -220,7 +220,7 @@ define('test', ['ss'], function(ss) {
     /// <summary>
     /// Runs.
     /// </summary>
-  }
+  };
 
 
   // BasicTests.DerivedClass

--- a/tests/TestCases/Basic/Metadata/Baseline.txt
+++ b/tests/TestCases/Basic/Metadata/Baseline.txt
@@ -3816,7 +3816,7 @@ define('test', ['ss'], function(ss) {
   // BasicTests.Util
 
   $global.showHelp = function() {
-  }
+  };
 
 
   var $exports = ss.module('test',

--- a/tests/TestCases/Basic/Minimization/Baseline.txt
+++ b/tests/TestCases/Basic/Minimization/Baseline.txt
@@ -67,7 +67,7 @@ define('test', ['ss', 'lib'], function(ss, lib) {
   // BasicTests.GlobalMethodsClass
 
   $global.run = function() {
-  }
+  };
 
 
   // BasicTests.BaseBaseClass

--- a/tests/TestCases/Expression/AnonymousMethods/Baseline.txt
+++ b/tests/TestCases/Expression/AnonymousMethods/Baseline.txt
@@ -23,12 +23,12 @@ define('test', ['ss'], function(ss) {
     ExpressionTests$Test.doStuffStatic(o, function(i, s, b) {
       name = s;
     });
-  }
+  };
   ExpressionTests$Test.doStuffStatic = function(o, callback) {
     var s = new ExpressionTests$SomeClass(function() {
       var temp = o;
     });
-  }
+  };
   var ExpressionTests$Test$ = {
     AAA: function() {
       var $this = this;

--- a/tests/TestCases/Expression/Delegates/Baseline.txt
+++ b/tests/TestCases/Expression/Delegates/Baseline.txt
@@ -49,7 +49,7 @@ define('test', ['ss'], function(ss) {
   function ExpressionTests$Test2() {
   }
   ExpressionTests$Test2.onGlobalEvent = function(sender, e) {
-  }
+  };
   var ExpressionTests$Test2$ = {
 
   };

--- a/tests/TestCases/Expression/Events/Baseline.txt
+++ b/tests/TestCases/Expression/Events/Baseline.txt
@@ -9,10 +9,10 @@ define('test', ['ss'], function(ss) {
   }
   ExpressionTests$Button.add_test = function(value) {
     ExpressionTests$Button.__test = ss.bindAdd(ExpressionTests$Button.__test, value);
-  }
+  };
   ExpressionTests$Button.remove_test = function(value) {
     ExpressionTests$Button.__test = ss.bindSub(ExpressionTests$Button.__test, value);
-  }
+  };
   var ExpressionTests$Button$ = {
     add_click: function(value) {
       this.__click = ss.bindAdd(this.__click, value);
@@ -68,7 +68,7 @@ define('test', ['ss'], function(ss) {
     this._btn.remove_aaa(ss.bind('_onAAAButton', this));
   }
   ExpressionTests$App._onTestButton = function(sender, e) {
-  }
+  };
   var ExpressionTests$App$ = {
     _onAAAButton: function(sender, e) {
     },

--- a/tests/TestCases/Expression/ExtensionMethods/Baseline.txt
+++ b/tests/TestCases/Expression/ExtensionMethods/Baseline.txt
@@ -19,7 +19,7 @@ define('test', ['ss'], function(ss) {
   // ExpressionTests.Util
 
   $global.foo = function() {
-  }
+  };
 
 
   var $exports = ss.module('test', null,

--- a/tests/TestCases/Expression/New/Baseline.txt
+++ b/tests/TestCases/Expression/New/Baseline.txt
@@ -59,7 +59,7 @@ define('test', ['ss'], function(ss) {
     var f1 = new Function("alert('hello');");
     var f2 = new Function('s', 'alert(s);');
     var f3 = new Function('greeting', 'name', "alert(greeting + ' ' + name + '!');");
-  }
+  };
   var ExpressionTests$Test$ = {
 
   };

--- a/tests/TestCases/Library/jQuery/Baseline.txt
+++ b/tests/TestCases/Library/jQuery/Baseline.txt
@@ -15,7 +15,7 @@ define('test', ['ss', 'jquery'], function(ss, $) {
     }, error: function(xhr, textData, e) {
       console.log(xhr.status);
     } });
-  }
+  };
   MyApp.postData = function(url, data, succesCallback, errorCallback, returnType, requestType) {
     returnType = returnType || 'text';
     requestType = requestType || 'POST';
@@ -31,7 +31,7 @@ define('test', ['ss', 'jquery'], function(ss, $) {
         succesCallback(dataSuccess, textStatus, request);
       }
     }, type: requestType, url: url });
-  }
+  };
   var MyApp$ = {
 
   };

--- a/tests/TestCases/Member/Events/Baseline.txt
+++ b/tests/TestCases/Member/Events/Baseline.txt
@@ -18,10 +18,10 @@ define('test', ['ss'], function(ss) {
   }
   MemberTests$Button.add_test = function(value) {
     MemberTests$Button.__test = ss.bindAdd(MemberTests$Button.__test, value);
-  }
+  };
   MemberTests$Button.remove_test = function(value) {
     MemberTests$Button.__test = ss.bindSub(MemberTests$Button.__test, value);
-  }
+  };
   var MemberTests$Button$ = {
     add_click: function(value) {
       this.__click = ss.bindAdd(this.__click, value);

--- a/tests/TestCases/Member/Indexers/Baseline.txt
+++ b/tests/TestCases/Member/Indexers/Baseline.txt
@@ -180,7 +180,7 @@ define('test', ['ss'], function(ss) {
     c.set_item('a', c.get_item('b'));
     var a = c;
     a.set_item('b', a.get_item('c'));
-  }
+  };
   var MemberTests$C$ = {
     get_item: function(name) {
       return name;

--- a/tests/TestCases/Member/Methods/Baseline.txt
+++ b/tests/TestCases/Member/Methods/Baseline.txt
@@ -35,15 +35,15 @@ define('test', ['ss'], function(ss) {
   // MemberTests.Foo
 
   $global.doStuff = function() {
-  }
+  };
 
 
   // MemberTests.Bar
 
   window.m1 = function() {
-  }
+  };
   window.m2 = function() {
-  }
+  };
 
 
   // MemberTests.X
@@ -61,7 +61,7 @@ define('test', ['ss'], function(ss) {
   $.fn.extend = function(x, i) {
     x.update(i);
     return x;
-  }
+  };
 
 
   var $exports = ss.module('test', null,

--- a/tests/TestCases/Member/Overloads/Baseline.txt
+++ b/tests/TestCases/Member/Overloads/Baseline.txt
@@ -8,7 +8,7 @@ define('test', ['ss'], function(ss) {
   function MemberTests$Test(name) {
   }
   MemberTests$Test.doSomething = function(o) {
-  }
+  };
   var MemberTests$Test$ = {
     invoke: function(successCallback, errorCallback, context) {
     }

--- a/tests/TestCases/Member/Properties/Baseline.txt
+++ b/tests/TestCases/Member/Properties/Baseline.txt
@@ -14,10 +14,10 @@ define('test', ['ss'], function(ss) {
   }
   MemberTests$Test.get_staticProp = function() {
     return 2006;
-  }
+  };
   MemberTests$Test.set_staticProp = function(value) {
     return value;
-  }
+  };
   var MemberTests$Test$ = {
     get_XYZ: function() {
       return 0;

--- a/tests/TestCases/Type/Enums/Baseline.txt
+++ b/tests/TestCases/Type/Enums/Baseline.txt
@@ -64,7 +64,7 @@ define('test', ['ss'], function(ss) {
     var m = 1;
     m = 1 | 4;
     var c = 0;
-  }
+  };
   var TypeTests$App$ = {
 
   };


### PR DESCRIPTION
JSHint complained about missing ";" after function declarations in
generated code, which is correct.

Before it was:

``` javascript
Foo.Bar = function() {
}
```

Now public static functions and property accessors are generated as
assignment with trailing ";":

``` javascript
Foo.Bar = function() {
};
```
