### PR TITLE
TestCase for base method Calls, see Issue #295

### DIFF
--- a/src/Tools/Testing/WebBrowser.cs
+++ b/src/Tools/Testing/WebBrowser.cs
@@ -47,9 +47,9 @@ namespace ScriptSharp.Testing {
         private static string GetChromeExecutablePath() {
             string path = null;
 
-            RegistryKey chromeKey = Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Uninstall\Google Chrome\");
+            RegistryKey chromeKey = Registry.LocalMachine.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe\");
             if (chromeKey != null) {
-                path = Path.Combine((string)chromeKey.GetValue("InstallLocation"), "chrome.exe");
+                path = Path.Combine((string)chromeKey.GetValue("Path"), "chrome.exe");
                 if (!File.Exists(path)) {
                     path = null;
                 }

--- a/tests/TestSite/Code/OOP.cs
+++ b/tests/TestSite/Code/OOP.cs
@@ -42,6 +42,15 @@ namespace Test {
         public virtual string Die() {
             return "...";
         }
+
+        public virtual string Grow()
+        {
+            return this.Species + " has grown up";
+        }
+
+        public virtual string LiveThenDie(int i) {
+            return this.Live(0) + " " + this.Die();
+        }
     }
 
     public class Cat : Animal, IMammal {
@@ -55,6 +64,14 @@ namespace Test {
 
         public override string Die() {
             return base.Die();
+        }
+
+        public override string Grow() {
+            return base.Grow() + " " + base.Live(1);
+        }
+
+        public virtual string LiveThenSpeak() {
+            return base.Live(1) + " " + this.Speak();
         }
     }
 }
@@ -86,6 +103,15 @@ namespace Test.More {
 
         public override string Live(int i) {
             return base.Live(i) + " zzz";
+        }
+
+        public override string LiveThenSpeak()
+        {
+            return base.Live(2) + " " + base.Speak();
+        }
+
+        public string LiveThenSpeakThis() {
+            return this.Live(2) + " " + this.Speak();
         }
     }
 

--- a/tests/TestSite/TypeSystem.htm
+++ b/tests/TestSite/TypeSystem.htm
@@ -92,6 +92,29 @@ define(['ss', 'oop'], function(ss, oop) {
     QUnit.equal(g.die(), '...');
   });
 
+test('overrideable base method', function() {
+    var a = new oop.Animal("Mammal");
+    QUnit.equal(a.live(0), '[0] ...', 'Animal lived');
+    QUnit.equal(a.grow(), 'Mammal has grown up', 'Animal grew up');
+    QUnit.equal(a.die(), '...', 'Animal died');
+    QUnit.equal(a.liveThenDie(), '[0] ... ...', 'Animal lived and died');
+
+    var c = new oop.Cat();
+    QUnit.equal(c.live(1), '[1] ...', 'Cat lived like a Animal does');
+    QUnit.equal(c.grow(), 'Cat has grown up [1] ...', 'Cat grew up like a Cat does (overridden)'); //causing trouble
+    QUnit.equal(c.die(), '...', 'Cat died like a Cat does');
+    QUnit.equal(c.liveThenDie(), '[0] ... ...', 'Cat lived and died like a Animal does (not overidden)');
+    QUnit.equal(c.liveThenSpeak(), '[1] ... meow', 'Cat lived and spoke like a Cat does (overidden)'); //causing trouble
+    
+    var g = new oop.Garfield();
+    QUnit.equal(g.live(2), '[2] ... zzz', 'Garfield lived like a Garfield does (overidden)');
+    QUnit.equal(g.grow(), 'Cat has grown up [1] ...', 'Garfield grew up like a Cat does (not overridden)'); //not causing trouble
+    QUnit.equal(g.die(), '...', 'Garfield died like a Cat does (not overridden)');
+    QUnit.equal(g.liveThenDie(), '[0] ... zzz ...', 'Garfield lived and died like a Animal does (not overridden)');
+    QUnit.equal(g.liveThenSpeak(), '[2] ... meow', 'Garfield lived and spoke like a Cat does (overridden)'); //not causing trouble
+    QUnit.equal(g.liveThenSpeakThis(), '[2] ... zzz meow\r\nTranslation: I am fat, lazy, and cynical, but still, a favorite cat...', 'Garfield lived and spoke like only a Garfield does');
+  });
+
   test('typeOf', function() {
     var g = new oop.Garfield();
     QUnit.equal(ss.typeOf(g), oop.Garfield, "Expected Garfield instance.");


### PR DESCRIPTION
Always when you call a base method (other than that you are overwriting) in an overridden method, inheritance crashes.
Does not happen, if the other base method you are calling did itself got overridden in the same class, even when calling its own base. (workaround)

BTW: edited Chrome start because Registry Key did not exist (Win7, 64bit, Chrome 25)
