### PR TITLE
Stub to halt for Debugger

### DIFF
--- a/src/Core/CoreLib/Script.cs
+++ b/src/Core/CoreLib/Script.cs
@@ -61,6 +61,10 @@ namespace System {
             return null;
         }
 
+        [ScriptAlias("debugger")]
+        public static void Debugger() {
+        }
+        
         public static void DeleteField(object instance, string name) {
         }
 


### PR DESCRIPTION
Adding a stub to the debugger keyword which will explicitly halt program execution instead of typing Script.Literal("debugger") every time.
