### PR TITLE
set jQueryPosition wasn't possible

### DIFF
--- a/src/Libraries/jQuery/jQuery.Core/jQueryPosition.cs
+++ b/src/Libraries/jQuery/jQuery.Core/jQueryPosition.cs
@@ -39,7 +39,7 @@ namespace jQueryApi {
             }
         }
 
-        public static implicit operator Dictionary(jQueryPosition position) {
+        public static implicit operator jQueryPosition(Dictionary position) {
             return null;
         }
     }


### PR DESCRIPTION
now you can use [jQueryObject].Offset(new Dictionary("top", topvalue,
"left", leftvalue)); 
