### PR TITLE
Introduce QuerySelector and Trim Parameters

### DIFF
--- a/src/Core/CoreLib/String.cs
+++ b/src/Core/CoreLib/String.cs
@@ -379,17 +379,18 @@ namespace System {
             return null;
         }
 
-        public string Trim() {
+        [ScriptAlias("ss.trim")]
+        public string Trim(params char[] trimChars) {
             return null;
         }
 
         [ScriptAlias("ss.trimEnd")]
-        public string TrimEnd() {
+        public string TrimEnd(params char[] trimChars) {
             return null;
         }
 
         [ScriptAlias("ss.trimStart")]
-        public string TrimStart() {
+        public string TrimStart(params char[] trimChars) {
             return null;
         }
 

--- a/src/Core/Scripts/Runtime.js
+++ b/src/Core/Scripts/Runtime.js
@@ -72,6 +72,7 @@
       padRight: padRight,
       trimStart: trimStart,
       trimEnd: trimEnd,
+      trim: trim,
       insertString: insertString,
       removeString: removeString,
       replaceString: replaceString,

--- a/src/Core/Scripts/Runtime/String.js
+++ b/src/Core/Scripts/Runtime/String.js
@@ -58,10 +58,35 @@ function format(cultureOrFormat) {
     });
 }
 
-function trimStart(s) {
+function trim(s, trimChars) {
+  if (trimChars != null || typeof String.prototype.trim !== 'function') {
+    if (trimChars.constructor != Array) {
+      trimChars = Array.prototype.slice.call(arguments, 1);
+    }
+    return ss.trimEnd(ss.trimStart(s, trimChars), trimChars);
+  }
+  return s.trim();
+}
+function trimStart(s, trimChars) {
+  if (trimChars != null) {
+    var values = Array.prototype.slice.call(arguments, 1);
+    if (values[0].constructor != String) {
+      values = values[0];
+    }
+    var pattern = '^[' + values.join('') + ']*';
+    return s.replace(new RegExp(pattern, ''), '');
+  }
   return s.replace(/^\s*/, '');
 }
-function trimEnd(s) {
+function trimEnd(s, trimChars) {
+  if (trimChars != null) {
+    var values = Array.prototype.slice.call(arguments, 1);
+    if (values[0].constructor != String) {
+      values = values[0];
+    }
+    var pattern = '[' + values.join('') + ']*$';
+    return s.replace(new RegExp(pattern, ''), '');
+  }
   return s.replace(/\s*$/, '');
 }
 function startsWith(s, prefix) {

--- a/src/Libraries/Web/Xml/XmlNode.cs
+++ b/src/Libraries/Web/Xml/XmlNode.cs
@@ -161,6 +161,14 @@ namespace System.Xml {
             return null;
         }
 
+        public XmlNode QuerySelector(string selector) {
+            return null;
+        }
+
+        public XmlNodeList QuerySelectorAll(string selector) {
+            return null;
+        }
+
         public string TransformNode(XmlDocument stylesheet) {
             return null;
         }

--- a/src/Libraries/jQuery/jQuery.Core/jQueryPosition.cs
+++ b/src/Libraries/jQuery/jQuery.Core/jQueryPosition.cs
@@ -39,7 +39,7 @@ namespace jQueryApi {
             }
         }
 
-        public static implicit operator Dictionary(jQueryPosition position) {
+        public static implicit operator jQueryPosition(Dictionary position) {
             return null;
         }
     }

--- a/src/Libraries/jQuery/jQuery.Core/jQueryPosition.cs
+++ b/src/Libraries/jQuery/jQuery.Core/jQueryPosition.cs
@@ -47,7 +47,7 @@ namespace jQueryApi {
             }
         }
 
-        public static implicit operator jQueryPosition(Dictionary position) {
+        public static implicit operator Dictionary(jQueryPosition position) {
             return null;
         }
     }


### PR DESCRIPTION
Query Selector for XmlNode because SelectSingleNode is only available in IE
Trim with Paramaters to behave more like in .Net and also fixed compatibility to IE8

Sorry for the messy History, couldn't quickly figure out how to branch after work was done
