### PR TITLE
use short evaluation only for non enums

### DIFF
--- a/src/Core/Compiler/Generator/ExpressionGenerator.cs
+++ b/src/Core/Compiler/Generator/ExpressionGenerator.cs
@@ -176,8 +176,10 @@ namespace ScriptSharp.Generator {
                         }
                     }
                     else if ((literalExpression.Value is int) && (((int)literalExpression.Value) == 0)) {
-                        optimizable = true;
-                        checkForFalse = (expression.Operator == Operator.EqualEqualEqual);
+                        if (expression.LeftOperand.EvaluatedType.Type != SymbolType.Enumeration) {
+                            optimizable = true;
+                            checkForFalse = (expression.Operator == Operator.EqualEqualEqual);
+                        }
                     }
                     else if ((literalExpression.Value is string) && ((string)literalExpression.Value == String.Empty)) {
                         optimizable = true;


### PR DESCRIPTION
if there is a [ScriptConstants]enum starting with 0 comparism for "variable == enumvalue" was !enumvalue
if variable is object type in C# it leads to unexpected results (could be false or empty string) casted to int
now it compiles down to variable === 0
