### PR TITLE
implement Enum.GetName() 

### DIFF
--- a/src/Core/CoreLib/Enum.cs
+++ b/src/Core/CoreLib/Enum.cs
@@ -9,5 +9,10 @@ namespace System {
 
     [ScriptImport]
     public abstract class Enum : ValueType {
+        
+        [ScriptAlias("ss.enumgetname")]
+        public static string GetName(Type enumType, object value) {
+            return null;
+        }
     }
 }

--- a/src/Core/Scripts/Runtime.js
+++ b/src/Core/Scripts/Runtime.js
@@ -82,6 +82,7 @@
       bindSub: bindSub,
       bindExport: bindExport,
       deferred: deferred,
+      enumgetname: enumgetname,
 
       module: module,
       modules: _modules,

--- a/src/Core/Scripts/Runtime/Misc.js
+++ b/src/Core/Scripts/Runtime/Misc.js
@@ -76,6 +76,15 @@ function compareDates(d1, d2) {
   return (d1 === d2) ? true : ((isValue(d1) && isValue(d2)) ? (d1.getTime() == d2.getTime()) : false);
 }
 
+function enumgetname( t, v ) {
+    for ( var prop in t ) {
+        if ( t[prop] === v ) {
+            return prop;
+        }
+    }
+    return v;
+}
+
 function _popStackFrame(e) {
   if (!isValue(e.stack) ||
       !isValue(e.fileName) ||


### PR DESCRIPTION
if Enums are not decorated with [ScriptConstants(UseNames=true)] one
might need the Keyname to the Enumvalue

there is a workaround in C# which doesn't seem quiet obvious because it makes use of compiler specialities:

``` csharp
public enum designtype
{
    Panel = 0,
    Label = 1,
    TextBox = 2
}

designtype dtype = designtype.TextBox;
string dtypestring = "";

Dictionary<string, object> items = ((Dictionary<string, object>)((object)typeof(designtype)));
foreach (KeyValuePair<string, object> kvp in items)
{
    if ((int)items[kvp.Key] == (int)dtype)
        dtypestring = kvp.Key;
}
```

now the same is achived with .Net compatibility, whereas dtype could be int (javascript constant) as well:

``` csharp
Enum.GetName(typeof(designtype), dtype);
```
