### PR TITLE
Remove problematic optimization for local base class properties.

### DIFF
--- a/src/Core/Compiler/Generator/ExpressionGenerator.cs
+++ b/src/Core/Compiler/Generator/ExpressionGenerator.cs
@@ -860,13 +860,7 @@ namespace ScriptSharp.Generator {
                 Debug.Assert(baseClass != null);
 
                 writer.Write(baseClass.FullGeneratedName);
-                if (baseClass.IsApplicationType) {
-                    writer.Write("$.");
-                }
-                else {
-                    writer.Write(".prototype.");
-                }
-                writer.Write("get_");
+                writer.Write(".prototype.get_");
                 writer.Write(expression.Property.GeneratedName);
                 writer.Write(".call(");
                 writer.Write(generator.CurrentImplementation.ThisIdentifier);

--- a/tests/TestCases/Expression/Members/Baseline.txt
+++ b/tests/TestCases/Expression/Members/Baseline.txt
@@ -67,7 +67,7 @@ define('test', ['ss'], function(ss) {
     test2: function() {
       var n = this.get_XYZ();
       n = this.get_XYZ();
-      n = App$.get_XYZ.call(this);
+      n = App.prototype.get_XYZ.call(this);
       this.set_XYZ(n);
       this.set_XYZ(n);
       ss.base(this, 'set_XYZ').call(this, n);

--- a/tests/TestCases/Member/Properties/Baseline.txt
+++ b/tests/TestCases/Member/Properties/Baseline.txt
@@ -41,7 +41,7 @@ define('test', ['ss'], function(ss) {
 
   function Test2() {
     Test.call(this);
-    var n = Test$.get_XYZ.call(this);
+    var n = Test.prototype.get_XYZ.call(this);
     if (n === this.get_XYZ()) {
     }
     if (this.get_XYZ() === n) {


### PR DESCRIPTION
Per discussion in #379, the optimization for property expression generation was too optimistic: it assumed that the base class implements the property, but that's not necessarily the case -- it could be in some ancestor that isn't the base. The optimization is therefore removed. 

Ideally we'd walk up the inheritance chain at expression generation time to find the appropriate class and use that, but the penalty for prototype access should be minimal.
