### PR TITLE
Add tests for bases: methods, properties, indexers. Including generation skipping.

### DIFF
--- a/tests/ScriptTests.cs
+++ b/tests/ScriptTests.cs
@@ -22,6 +22,11 @@ namespace ScriptSharp.Tests {
             RunTest("/TypeSystem.htm");
         }
 
+        [TestMethod]
+        public void TestBases() {
+            RunTest("/Bases.htm");
+        }
+
         #region Loader Tests
         [TestMethod]
         public void TestLoader() {

--- a/tests/TestSite/Bases.htm
+++ b/tests/TestSite/Bases.htm
@@ -1,0 +1,45 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+  <title>Bases</title>
+  <link rel="stylesheet" href="QUnit/QUnit.css" type="text/css" />
+  <script type="text/javascript" src="QUnit/QUnit.js"></script>
+  <script type="text/javascript" src="QUnit/QUnitExt.js"></script>
+</head>
+<body>
+  <h1 id="qunit-header">Test Results</h1>
+  <h2 id="qunit-banner"></h2>
+  <h2 id="qunit-userAgent"></h2>
+  <ol id="qunit-tests"></ol>
+  <br />
+  <textarea id="qunit-log" rows="10" cols="100"></textarea>
+</body>
+
+<script type="text/javascript" src="Scripts/ssloader.min.js"></script>
+<script type="text/script" data-name="ss" data-src="Scripts/ss.min.js"></script>
+<script type="text/script" data-name="oop" data-src="Scripts/OOP.js"></script>
+
+<script type="text/script">
+define(['ss', 'oop'], function(ss, oop) {
+  module('OOP');
+
+  test('bases', function() {
+    var output1 = oop.TestCase.runTest(new oop.C1());
+    QUnit.equal(output1, "A-PC1,A-MC1,A-99IC1,X+PC1-PC1,Y+88IC1-99IC1", "Code path through base classes problem (C1)");
+
+    var output2 = oop.TestCase.runTest(new oop.C2());
+    QUnit.equal(output2, "A-PC1-PC2,A-MC1-MC2,A-99IC1-99IC2,X+PC2+PC1-PC1-PC2,Y+88IC2+88IC1-99IC1-99IC2", "Code path through base classes problem (C2)");
+
+    var output3 = oop.TestCase.runTest(new oop.C3());
+    QUnit.equal(output3, "A-PC1-PC2-PC3,A-MC1-MC2-MC3,A-99IC1-99IC2-99IC3,X+PC3+PC2+PC1-PC1-PC2-PC3,Y+88IC3+88IC2+88IC1-99IC1-99IC2-99IC3", "Code path through base classes problem (C3)");
+
+    // A C4 should act just like a C3 as it has no overrides
+    var output4 = oop.TestCase.runTest(new oop.C4());
+    QUnit.equal(output4, "A-PC1-PC2-PC3,A-MC1-MC2-MC3,A-99IC1-99IC2-99IC3,X+PC3+PC2+PC1-PC1-PC2-PC3,Y+88IC3+88IC2+88IC1-99IC1-99IC2-99IC3", "Code path through base classes problem (C4)");
+
+    var output5 = oop.TestCase.runTest(new oop.C5());
+    QUnit.equal(output5, "A-PC1-PC2-PC3-PC5,A-MC1-MC2-MC3-MC5,A-99IC1-99IC2-99IC3-99IC5,X+PC5+PC3+PC2+PC1-PC1-PC2-PC3-PC5,Y+88IC5+88IC3+88IC2+88IC1-99IC1-99IC2-99IC3-99IC5", "Code path through base classes problem (C5)");
+  });
+});
+</script>
+</html>

--- a/tests/TestSite/Code/OOP.cs
+++ b/tests/TestSite/Code/OOP.cs
@@ -9,22 +9,22 @@ namespace Test {
 
     public interface IMammal {
     }
-
+    
     public interface IPet {
-
+    
         string Name {
             get;
         }
-
+        
         string Owner {
             get;
         }
     }
-
+    
     public class Animal {
-
+    
         private string _species;
-
+        
         public Animal(string species) {
             _species = species;
         }
@@ -104,7 +104,7 @@ namespace Test.More {
                 return _name;
             }
         }
-
+        
         public ICharacter Star {
             get {
                 return _star;

--- a/tests/TestSite/Code/OOP.cs
+++ b/tests/TestSite/Code/OOP.cs
@@ -9,22 +9,22 @@ namespace Test {
 
     public interface IMammal {
     }
-    
+
     public interface IPet {
-    
+
         string Name {
             get;
         }
-        
+
         string Owner {
             get;
         }
     }
-    
+
     public class Animal {
-    
+
         private string _species;
-        
+
         public Animal(string species) {
             _species = species;
         }
@@ -104,7 +104,7 @@ namespace Test.More {
                 return _name;
             }
         }
-        
+
         public ICharacter Star {
             get {
                 return _star;
@@ -120,4 +120,141 @@ namespace Test.Misc {
 
     public class Zoo {
     }
+}
+
+
+namespace Test.Bases {
+
+    // A series of classes with different combinations of overrides at different
+    // levels in the class hierarchy. Tests issues #379, #384 as applied to properties,
+    // methods, and index operators.
+
+    public class C1 {
+        private string _valueA = "A";
+
+        public virtual string PropertyA {
+            get {
+                return _valueA + "-PC1";
+            }
+            set {
+                _valueA = value + "+PC1";
+            }
+        }
+
+        public virtual string MethodA() {
+            return _valueA + "-MC1";
+        }
+
+        public virtual string this[int key] {
+            get {
+                return _valueA + "-" + key.ToString() + "IC1";
+            }
+            set {
+                _valueA = value + "+" + key.ToString() + "IC1";
+            }
+        }
+    }
+
+    public class C2 : C1 {
+        public override string PropertyA {
+            get {
+                return base.PropertyA + "-PC2";
+            }
+            set {
+                base.PropertyA = value + "+PC2";
+            }
+        }
+
+        public override string MethodA() {
+            return base.MethodA() + "-MC2";
+        }
+
+        public override string this[int key] {
+            get {
+                return base[key] + "-" + key.ToString() + "IC2";
+            }
+            set {
+                base[key] = value + "+" + key.ToString() + "IC2";
+            }
+        }
+    }
+
+    public class C3 : C2 {
+        public override string PropertyA {
+            get {
+                return base.PropertyA + "-PC3";
+            }
+            set {
+                base.PropertyA = value + "+PC3";
+            }
+        }
+
+        public override string MethodA() {
+            return base.MethodA() + "-MC3";
+        }
+
+        public override string this[int key] {
+            get {
+                return base[key] + "-" + key.ToString() + "IC3";
+            }
+            set {
+                base[key] = value + "+" + key.ToString() + "IC3";
+            }
+        }
+    }
+
+    public class C4 : C3 {
+        // intentionally skip this generation of overrides
+    }
+
+    public class C5 : C4 {
+        public override string PropertyA {
+            get {
+                return base.PropertyA + "-PC5";
+            }
+            set {
+                base.PropertyA = value + "+PC5";
+            }
+        }
+
+        public override string MethodA() {
+            return base.MethodA() + "-MC5";
+        }
+
+        public override string this[int key] {
+            get {
+                return base[key] + "-" + key.ToString() + "IC5";
+            }
+            set {
+                base[key] = value + "+" + key.ToString() + "IC5";
+            }
+        }
+    }
+
+    public class TestCase {
+
+        public static string RunTest(C1 x) {
+            string output = "";
+            string delim = ",";
+
+            // Test getter, method, and index (should accumulate outward through bases)
+            output = x.PropertyA
+                    + delim + x.MethodA()
+                    + delim + x[99];
+
+            // Test property setter (should accumulate inward and outward through bases)
+
+            x.PropertyA = "X";
+            output += delim + x.PropertyA;
+
+            // Test index setter (should accumulate inward and outward through bases)
+
+            x[88] = "Y";
+            output += delim + x[99];
+
+            return output;
+        }
+
+    }
+
 }


### PR DESCRIPTION
Tests for base.\* and specifically regressions of #379, #384. Verifies that base classes are called properly both when immediate and skipping a generation (ie, implementing base is not immediate parent). Verifies setters, getters, index getters, index setters, and methods.
