### PR TITLE
Add missing namespaced methods to Html.Document. And ImportNode.

### DIFF
--- a/src/Libraries/Web/Html/Document.cs
+++ b/src/Libraries/Web/Html/Document.cs
@@ -148,7 +148,25 @@ namespace System.Html {
         public static void AttachEvent(string eventName, ElementEventHandler handler) {
         }
 
+        /// <summary>
+        /// Creates an Attr of the given name. Note that the Attr instance can then be set on an 
+        /// Element using the setAttributeNode method. To create an attribute with a qualified name 
+        /// and namespace URI, use the CreateAttributeNS method.
+        /// </summary>
+        /// <param name="name">The name of the attribute.</param>
+        /// <returns>A new Attr object with the nodeName attribute set to name, and localName, prefix, 
+        /// and namespaceURI set to null. The value of the attribute is the empty string.</returns>
         public static ElementAttribute CreateAttribute(string name) {
+            return null;
+        }
+
+        /// <summary>
+        /// Creates an attribute of the given qualified name and namespace URI.
+        /// </summary>
+        /// <param name="namespaceURI">The namespace URI of the attribute to create.</param>
+        /// <param name="qualifiedName">The qualified name of the attribute to instantiate.</param>
+        /// <returns>A new Attr object with the given namespace and qualified name.</returns>
+        public static ElementAttribute CreateAttributeNS(string namespaceURI, string qualifiedName) {
             return null;
         }
 
@@ -156,7 +174,24 @@ namespace System.Html {
             return null;
         }
 
+        /// <summary>
+        /// Creates an element of the type specified. 
+        /// To create an element with a qualified name and namespace URI, use the CreateElementNS method.
+        /// </summary>
+        /// <param name="tagName">The name of the element type to instantiate.</param>
+        /// <returns>A new Element object with the nodeName attribute set to tagName, and localName, 
+        /// prefix, and namespaceURI set to null.</returns>
         public static Element CreateElement(string tagName) {
+            return null;
+        }
+
+        /// <summary>
+        /// Creates an element of the given qualified name and namespace URI. 
+        /// </summary>
+        /// <param name="namespaceURI">The namespace URI of the element to create.</param>
+        /// <param name="qualifiedName">The qualified name of the element type to instantiate.</param>
+        /// <returns>A new Element object with the given namespace and qualified name.</returns>
+        public static Element CreateElementNS(string namespaceURI, string qualifiedName) {
             return null;
         }
 
@@ -168,6 +203,10 @@ namespace System.Html {
             return null;
         }
 
+        public static Element ImportNode(Element imporedNode, bool deep) {
+            return null;
+        }
+        
         public static void DetachEvent(string eventName, ElementEventHandler handler) {
         }
 
@@ -203,6 +242,16 @@ namespace System.Html {
         }
 
         public static ElementCollection GetElementsByTagName(string tagName) {
+            return null;
+        }
+
+        /// <summary>
+        /// Returns a NodeList of all the Elements with a given local name and namespace URI in the order in which they are encountered in a preorder traversal of the Document tree.
+        /// </summary>
+        /// <param name="namespaceURI">The namespace URI of the elements to match on. The special value "*" matches all namespaces.</param>
+        /// <param name="localName">The local name of the elements to match on. The special value "*" matches all local names.</param>
+        /// <returns>A new NodeList object containing all the matched Elements.</returns>
+        public static ElementCollection GetElementsByTagNameNS(string namespaceURI, string localName) {
             return null;
         }
 


### PR DESCRIPTION
Need CreateElementNS for any kind of SVG work (for example). For completeness, added the other namespaced methods. As well as ImportNode, which fills out the DOM Level 2 implementation for Document.

See http://www.w3.org/TR/DOM-Level-2-Core/core.html.
