### PR TITLE
NodeApi.IO.Buffer.Length should be a simple property accessor.

### DIFF
--- a/src/Libraries/Node/Node.Core/IO/Buffer.cs
+++ b/src/Libraries/Node/Node.Core/IO/Buffer.cs
@@ -24,6 +24,7 @@ namespace NodeApi.IO {
         public Buffer(string data, Encoding encoding) {
         }
 
+        [ScriptField]
         public int Length {
             get {
                 return 0;


### PR DESCRIPTION
For reference see http://nodejs.org/api/buffer.html#buffer_buf_length.
