### PR TITLE
IE8 StringBuilder toString bugfix

### DIFF
--- a/src/Core/Scripts/Runtime/StringBuilder.js
+++ b/src/Core/Scripts/Runtime/StringBuilder.js
@@ -3,6 +3,9 @@
 function StringBuilder(s) {
   this._parts = isValue(s) && s !== '' ? [s] : [];
   this.isEmpty = this._parts.length == 0;
+  if (this.toString === Object.prototype.toString) {
+    this.toString = function(s) { return this._parts.join(s || ''); };
+  }
 }
 var StringBuilder$ = {
   append: function(s) {


### PR DESCRIPTION
Before :
var t = new ss.StringBuilder;
t.appendLine("toString overriden"),
var s = t.toString(); // IE8 returns [object Object]

After :
var t = new ss.StringBuilder;
t.appendLine("IE8 toString override bug"),
var s = t.toString(); // IE8 returns "toString overriden"

More informations on this bug :
http://stackoverflow.com/questions/6821354/issues-with-object-tostring-in-ie8-backbone-js

Runtime scripts :
I have search for every "toString" that was overriden in scriptsharp "Runtime scripts" 
but only found this one.

Compiled scripts :
ScriptSharp compiler prevent overriding "toString" with a "Your C# source code use an 
unsupported feature" error.

Thanks for your time.
Regards
Luc
