### PR TITLE
Add ability to specify the default member case preservation in an assembly

### DIFF
--- a/src/Core/Compiler/Importer/MetadataHelpers.cs
+++ b/src/Core/Compiler/Importer/MetadataHelpers.cs
@@ -29,6 +29,10 @@ namespace ScriptSharp.Importer {
             return attribute.ConstructorArguments[0].Value as string;
         }
 
+        private static bool GetBoolAttributeArgument(CustomAttribute attribute) {
+            return (bool)attribute.ConstructorArguments[0].Value;
+        }
+
         public static string GetScriptAlias(ICustomAttributeProvider attributeProvider) {
             CustomAttribute scriptAliasAttribute = GetAttribute(attributeProvider, "System.Runtime.CompilerServices.ScriptAliasAttribute");
             if (scriptAliasAttribute != null) {
@@ -52,6 +56,14 @@ namespace ScriptSharp.Importer {
             }
 
             return null;
+        }
+
+        public static bool GetScriptDefaultMemberCasePreservation(ICustomAttributeProvider attributeProvider) {
+            CustomAttribute memberCasePreservationAttribute = GetAttribute(attributeProvider, "System.ScriptDefaultMemberCasePreservation");
+            if (memberCasePreservationAttribute != null) {
+                return GetBoolAttributeArgument(memberCasePreservationAttribute);
+            }
+            return false;
         }
 
         public static string GetScriptDependencyName(ICustomAttributeProvider attributeProvider, out string dependencyIdentifier) {
@@ -94,9 +106,9 @@ namespace ScriptSharp.Importer {
             return null;
         }
 
-        public static string GetScriptName(ICustomAttributeProvider attributeProvider, out bool preserveName, out bool preserveCase) {
+        public static string GetScriptName(ICustomAttributeProvider attributeProvider, bool defaultPreserveCaseValue, out bool preserveName, out bool preserveCase) {
             string name = null;
-            preserveName = false;
+            preserveName = defaultPreserveCaseValue;
             preserveCase = false;
 
             CustomAttribute nameAttribute = GetAttribute(attributeProvider, "System.ScriptNameAttribute");

--- a/src/Core/Compiler/ScriptModel/Symbols/TypeSymbol.cs
+++ b/src/Core/Compiler/ScriptModel/Symbols/TypeSymbol.cs
@@ -33,6 +33,7 @@ namespace ScriptSharp.ScriptModel {
         private bool _ignoreNamespace;
         private string _scriptNamespace;
         private bool _testType;
+        private bool _memberCasePreservation;
 
         protected TypeSymbol(SymbolType type, string name, NamespaceSymbol parent)
             : base(type, name, parent) {
@@ -192,6 +193,20 @@ namespace ScriptSharp.ScriptModel {
             }
             set {
                 _scriptNamespace = value;
+            }
+        }
+
+        /// <summary>
+        /// The casing of this type's members names is preserved
+        /// according to this value unless overriden through a 
+        /// ScriptName attribute on the member.
+        /// </summary>
+        public bool MemberCasePreservation {
+            get {
+                return _memberCasePreservation;
+            }
+            set {
+                _memberCasePreservation = value;
             }
         }
 

--- a/src/Core/CoreLib/ScriptMetadata.cs
+++ b/src/Core/CoreLib/ScriptMetadata.cs
@@ -359,4 +359,23 @@ namespace System.Runtime.CompilerServices {
             }
         }
     }
+
+    [AttributeUsage(AttributeTargets.Assembly)]
+    [ScriptIgnore]
+    public sealed class ScriptDefaultMemberCasePreservation : Attribute {
+        private bool _preserveMemberCase;
+
+        public ScriptDefaultMemberCasePreservation(bool preserveMemberCase) {
+            _preserveMemberCase = preserveMemberCase;
+        }
+
+        public bool PerserveMemberCase {
+            get {
+                return _preserveMemberCase;
+            }
+            set {
+                _preserveMemberCase = value;
+            }
+        }
+    }
 }

--- a/tests/CasePreservationTests.cs
+++ b/tests/CasePreservationTests.cs
@@ -1,0 +1,50 @@
+﻿// CasePreservationTests.cs
+// Script#/Tests
+// This source code is subject to terms and conditions of the Apache License, Version 2.0.
+//
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ScriptSharp.Tests.Core;
+
+namespace ScriptSharp.Tests {
+
+    [TestClass]
+    public class CasePreservationTests :  CompilationTest {
+
+        [TestMethod]
+        public void TestDefaultCase() {
+            RunTest((c) => {
+                c.AddSource("Code.cs");
+            });
+        }
+
+        [TestMethod]
+        public void TestAllMembersCasePreserved() {
+            RunTest((c) => {
+                c.AddSource("Code.cs");
+            });
+        }
+
+        [TestMethod]
+        public void TestNoMemberCasePreserved() {
+            RunTest((c) => {
+                c.AddSource("Code.cs");
+            });
+        }
+
+        [TestMethod]
+        public void TestOneTypesMembersCaseNotPreserved() {
+            RunTest((c) => {
+                c.AddSource("Code.cs");
+            });
+        }
+
+        [TestMethod]
+        public void TestOneMemberCaseNotPreserved() {
+            RunTest((c) => {
+                c.AddSource("Code.cs");
+            });
+        }
+    }
+}

--- a/tests/TestCases/CasePreservation/AllMembersCasePreserved/Baseline.txt
+++ b/tests/TestCases/CasePreservation/AllMembersCasePreserved/Baseline.txt
@@ -1,0 +1,43 @@
+"use strict";
+
+define('test', ['ss'], function(ss) {
+  var $global = this;
+
+  // CasePreservationTests.Foo
+
+  function Foo(i, j) {
+  }
+  var Foo$ = {
+    ToString: function() {
+      return 'Foo';
+    },
+    Sum: function(i) {
+      return 0;
+    }
+  };
+
+
+  // CasePreservationTests.Bar
+
+  function Bar(i, j, f) {
+    Foo.call(this, i, j);
+  }
+  var Bar$ = {
+    Sum: function() {
+      return Foo.prototype.Sum.call(this, 1) + 1;
+    },
+    ToString: function() {
+      return Foo.prototype.ToString.call(this) + ' -> Bar';
+    }
+  };
+
+
+  var $exports = ss.module('test', null,
+    {
+      Foo: [ Foo, Foo$, null ],
+      Bar: [ Bar, Bar$, Foo ]
+    });
+
+
+  return $exports;
+});

--- a/tests/TestCases/CasePreservation/AllMembersCasePreserved/Code.cs
+++ b/tests/TestCases/CasePreservation/AllMembersCasePreserved/Code.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Runtime.CompilerServices;
+
+[assembly: ScriptAssembly("test")]
+[assembly: ScriptDefaultMemberCasePreservation(true)]
+
+namespace CasePreservationTests {
+
+    public class Foo {
+
+        public Foo(int i, int j) {
+        }
+
+        public override string ToString() {
+            return "Foo";
+        }
+
+        public virtual int Sum(int i) {
+            return 0;
+        }
+    }
+
+    public class Bar : Foo {
+
+        public Bar(int i, int j, Foo f) : base(i, j) {
+        }
+
+        public override int Sum() {
+            return base.Sum(1) + 1;
+        }
+
+        public override string ToString() {
+            return base.ToString() + " -> Bar";
+        }
+    }
+}

--- a/tests/TestCases/CasePreservation/DefaultCase/Baseline.txt
+++ b/tests/TestCases/CasePreservation/DefaultCase/Baseline.txt
@@ -1,0 +1,43 @@
+"use strict";
+
+define('test', ['ss'], function(ss) {
+  var $global = this;
+
+  // CasePreservationTests.Foo
+
+  function Foo(i, j) {
+  }
+  var Foo$ = {
+    toString: function() {
+      return 'Foo';
+    },
+    sum: function(i) {
+      return 0;
+    }
+  };
+
+
+  // CasePreservationTests.Bar
+
+  function Bar(i, j, f) {
+    Foo.call(this, i, j);
+  }
+  var Bar$ = {
+    sum: function() {
+      return Foo.prototype.sum.call(this, 1) + 1;
+    },
+    toString: function() {
+      return Foo.prototype.toString.call(this) + ' -> Bar';
+    }
+  };
+
+
+  var $exports = ss.module('test', null,
+    {
+      Foo: [ Foo, Foo$, null ],
+      Bar: [ Bar, Bar$, Foo ]
+    });
+
+
+  return $exports;
+});

--- a/tests/TestCases/CasePreservation/DefaultCase/Code.cs
+++ b/tests/TestCases/CasePreservation/DefaultCase/Code.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Runtime.CompilerServices;
+
+[assembly: ScriptAssembly("test")]
+
+namespace CasePreservationTests {
+
+    public class Foo {
+
+        public Foo(int i, int j) {
+        }
+
+        public override string ToString() {
+            return "Foo";
+        }
+
+        public virtual int Sum(int i) {
+            return 0;
+        }
+    }
+
+    public class Bar : Foo {
+
+        public Bar(int i, int j, Foo f) : base(i, j) {
+        }
+
+        public override int Sum() {
+            return base.Sum(1) + 1;
+        }
+
+        public override string ToString() {
+            return base.ToString() + " -> Bar";
+        }
+    }
+}

--- a/tests/TestCases/CasePreservation/NoMemberCasePreserved/Baseline.txt
+++ b/tests/TestCases/CasePreservation/NoMemberCasePreserved/Baseline.txt
@@ -1,0 +1,43 @@
+"use strict";
+
+define('test', ['ss'], function(ss) {
+  var $global = this;
+
+  // CasePreservationTests.Foo
+
+  function Foo(i, j) {
+  }
+  var Foo$ = {
+    toString: function() {
+      return 'Foo';
+    },
+    sum: function(i) {
+      return 0;
+    }
+  };
+
+
+  // CasePreservationTests.Bar
+
+  function Bar(i, j, f) {
+    Foo.call(this, i, j);
+  }
+  var Bar$ = {
+    sum: function() {
+      return Foo.prototype.sum.call(this, 1) + 1;
+    },
+    toString: function() {
+      return Foo.prototype.toString.call(this) + ' -> Bar';
+    }
+  };
+
+
+  var $exports = ss.module('test', null,
+    {
+      Foo: [ Foo, Foo$, null ],
+      Bar: [ Bar, Bar$, Foo ]
+    });
+
+
+  return $exports;
+});

--- a/tests/TestCases/CasePreservation/NoMemberCasePreserved/Code.cs
+++ b/tests/TestCases/CasePreservation/NoMemberCasePreserved/Code.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Runtime.CompilerServices;
+
+[assembly: ScriptAssembly("test")]
+[assembly: ScriptDefaultMemberCasePreservation(false)]
+
+namespace CasePreservationTests {
+
+    public class Foo {
+
+        public Foo(int i, int j) {
+        }
+
+        public override string ToString() {
+            return "Foo";
+        }
+
+        public virtual int Sum(int i) {
+            return 0;
+        }
+    }
+
+    public class Bar : Foo {
+
+        public Bar(int i, int j, Foo f) : base(i, j) {
+        }
+
+        public override int Sum() {
+            return base.Sum(1) + 1;
+        }
+
+        public override string ToString() {
+            return base.ToString() + " -> Bar";
+        }
+    }
+}

--- a/tests/TestCases/CasePreservation/OneMemberCaseNotPreserved/Baseline.txt
+++ b/tests/TestCases/CasePreservation/OneMemberCaseNotPreserved/Baseline.txt
@@ -1,0 +1,43 @@
+"use strict";
+
+define('test', ['ss'], function(ss) {
+  var $global = this;
+
+  // CasePreservationTests.Foo
+
+  function Foo(i, j) {
+  }
+  var Foo$ = {
+    ToString: function() {
+      return 'Foo';
+    },
+    sum: function(i) {
+      return 0;
+    }
+  };
+
+
+  // CasePreservationTests.Bar
+
+  function Bar(i, j, f) {
+    Foo.call(this, i, j);
+  }
+  var Bar$ = {
+    Sum: function() {
+      return Foo.prototype.sum.call(this, 1) + 1;
+    },
+    ToString: function() {
+      return Foo.prototype.ToString.call(this) + ' -> Bar';
+    }
+  };
+
+
+  var $exports = ss.module('test', null,
+    {
+      Foo: [ Foo, Foo$, null ],
+      Bar: [ Bar, Bar$, Foo ]
+    });
+
+
+  return $exports;
+});

--- a/tests/TestCases/CasePreservation/OneMemberCaseNotPreserved/Code.cs
+++ b/tests/TestCases/CasePreservation/OneMemberCaseNotPreserved/Code.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Runtime.CompilerServices;
+
+[assembly: ScriptAssembly("test")]
+[assembly: ScriptDefaultMemberCasePreservation(true)]
+
+namespace CasePreservationTests {
+
+    public class Foo {
+
+        public Foo(int i, int j) {
+        }
+
+        public override string ToString() {
+            return "Foo";
+        }
+
+        [ScriptName(PreserveCase=false)]
+        public virtual int Sum(int i) {
+            return 0;
+        }
+    }
+
+    public class Bar : Foo {
+
+        public Bar(int i, int j, Foo f) : base(i, j) {
+        }
+
+        public override int Sum() {
+            return base.Sum(1) + 1;
+        }
+
+        public override string ToString() {
+            return base.ToString() + " -> Bar";
+        }
+    }
+}

--- a/tests/TestCases/CasePreservation/OneTypesMembersCaseNotPreserved/Baseline.txt
+++ b/tests/TestCases/CasePreservation/OneTypesMembersCaseNotPreserved/Baseline.txt
@@ -1,0 +1,43 @@
+"use strict";
+
+define('test', ['ss'], function(ss) {
+  var $global = this;
+
+  // CasePreservationTests.Foo
+
+  function Foo(i, j) {
+  }
+  var Foo$ = {
+    toString: function() {
+      return 'Foo';
+    },
+    sum: function(i) {
+      return 0;
+    }
+  };
+
+
+  // CasePreservationTests.Bar
+
+  function Bar(i, j, f) {
+    Foo.call(this, i, j);
+  }
+  var Bar$ = {
+    Sum: function() {
+      return Foo.prototype.sum.call(this, 1) + 1;
+    },
+    ToString: function() {
+      return Foo.prototype.toString.call(this) + ' -> Bar';
+    }
+  };
+
+
+  var $exports = ss.module('test', null,
+    {
+      Foo: [ Foo, Foo$, null ],
+      Bar: [ Bar, Bar$, Foo ]
+    });
+
+
+  return $exports;
+});

--- a/tests/TestCases/CasePreservation/OneTypesMembersCaseNotPreserved/Code.cs
+++ b/tests/TestCases/CasePreservation/OneTypesMembersCaseNotPreserved/Code.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Runtime.CompilerServices;
+
+[assembly: ScriptAssembly("test")]
+[assembly: ScriptDefaultMemberCasePreservation(true)]
+
+namespace CasePreservationTests {
+
+    [ScriptName(PreserveCase=false)]
+    public class Foo {
+
+        public Foo(int i, int j) {
+        }
+
+        public override string ToString() {
+            return "Foo";
+        }
+
+        public virtual int Sum(int i) {
+            return 0;
+        }
+    }
+
+    public class Bar : Foo {
+
+        public Bar(int i, int j, Foo f) : base(i, j) {
+        }
+
+        public override int Sum() {
+            return base.Sum(1) + 1;
+        }
+
+        public override string ToString() {
+            return base.ToString() + " -> Bar";
+        }
+    }
+}

--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -59,6 +59,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BasicTests.cs" />
+    <Compile Include="CasePreservationTests.cs" />
     <Compile Include="Core\BrowserTest.cs" />
     <Compile Include="Core\SimpleCompilation.cs" />
     <Compile Include="ExpressionTests.cs" />


### PR DESCRIPTION
Add ability to specify the default member case preservation to be used throughout an assembly. The compiler always defaults to not preserving member casing without this feature.

Also add the ability to specify the case preservation of all members of a type through ScriptName.PreserveCase property on the type.
